### PR TITLE
HANA express tutorials, fix broken images

### DIFF
--- a/tutorials/hxe-ua-installing-binary/hxe-ua-installing-binary.md
+++ b/tutorials/hxe-ua-installing-binary/hxe-ua-installing-binary.md
@@ -61,7 +61,7 @@ For troubleshooting information, see [SAP HANA, express edition Troubleshooting]
     >![Windows SmartScreen](Windows_Runner.jpg)
 
 4. In Download Manager, in the **Image** pull-down, select **Binary Installer**.
-    ![Download Manager](HXE_download_manager.png)
+    ![Download Manager](HXE_download_manager.PNG)
 
 5. Click **Browse** and select a directory where your downloads will be saved.
 

--- a/tutorials/hxe-ua-installing-binary/hxe-ua-installing-binary.md
+++ b/tutorials/hxe-ua-installing-binary/hxe-ua-installing-binary.md
@@ -109,7 +109,7 @@ For troubleshooting information, see [SAP HANA, express edition Troubleshooting]
     6. When *Summary Before Execution* displays, click **y** to continue with installation.  
 
     >**Note**
-    >If a `libssl.so.0.9.8` error occurs, see [Installation Fails with Error "Cannot load libssl.so.0.9.8"](http://go.sap.com/developer/tutorials/hxe-ua-troubleshooting).
+    >If a `libssl.so.0.9.8` error occurs, see [Installation Fails with Error "Cannot load libssl.so.0.9.8"](http://go.sap.com/developer/how-tos/hxe-ua-troubleshooting.html).
 
 ### (Optional) Installing XSC, XS Advanced, and Web IDE
 

--- a/tutorials/hxe-ua-installing-vm-image/hxe-ua-installing-vm-image.md
+++ b/tutorials/hxe-ua-installing-vm-image/hxe-ua-installing-vm-image.md
@@ -64,7 +64,7 @@ The registration page opens.
 ![Registration Page](HXE_register.PNG)
 The **Registration Success** page displays. (You will also receive an email indicating successful registration.)
 3. At the bottom of the **Registration Success** page, click the download manager that matches your system: Linux or Windows. If you have a Mac, or another type of machine, click “other” for a platform-independent download manager.
-![Registration Success page](HXE_register_success.PNG)
+![Registration Success page](hxe_register_success.PNG)
 4. Save the download manager installation file to your laptop and open it.
 5. If Windows prevents the download manager installation file from running, click **More info** on the warning message and select **Run anyway**.  
 ![Windows warning](hxe_win_warning.PNG)


### PR DESCRIPTION
there are 2 broken images in the HANA express tutorials, this PR should fix the issue

![image](https://cloud.githubusercontent.com/assets/5888506/18643733/a1e3c25a-7ea6-11e6-9413-3234bcf13fdb.png)
