### PR TITLE
grunt best-practice version update to 1.3.58

### DIFF
--- a/tutorials/webide-grunt-basic/webide-grunt-basic.md
+++ b/tutorials/webide-grunt-basic/webide-grunt-basic.md
@@ -60,7 +60,7 @@ In the file enter the following code:
   "description": "Grunt build",
   "private": true,
   "devDependencies": {
-      "@sap/grunt-sapui5-bestpractice-build": "1.3.56"
+      "@sap/grunt-sapui5-bestpractice-build": "1.3.58"
    }
 }
 ```

--- a/tutorials/webide-grunt-plugins/webide-grunt-plugins.md
+++ b/tutorials/webide-grunt-plugins/webide-grunt-plugins.md
@@ -80,7 +80,7 @@ In the file enter the following code:
 	"private": true,
 	"dependencies": {
 		"grunt-ts": "X.X.X",
-		"@sap/grunt-sapui5-bestpractice-build": "1.3.56"
+		"@sap/grunt-sapui5-bestpractice-build": "1.3.58"
 	}
 }
 ```


### PR DESCRIPTION
This change will need to be published today ASAP. The release is out and these updates need to be published accordingly.