### PR TITLE
Add link to new mobile tutorial

### DIFF
--- a/tutorials/ci-best-practices-intro/ci-best-practices-intro.md
+++ b/tutorials/ci-best-practices-intro/ci-best-practices-intro.md
@@ -29,7 +29,8 @@ tags: [  tutorial>intermediate, tutorial:type/project ]
 4.4. [SAPUI5/SAP Fiori on ABAP Front End Server](https://www.sap.com/developer/tutorials/ci-best-practices-fiori-abap.html)  
 4.5. [SAPUI5/SAP Fiori on SAP Cloud Platform](https://www.sap.com/developer/tutorials/ci-best-practices-fiori-sapcp.html)  
 4.6. [SAP HANA Extended Application Services, advanced model (XS advanced) on SAP HANA](https://www.sap.com/developer/tutorials/ci-best-practices-xsa.html)  
-4.7. [SAP Cloud Platform SDK for iOS](https://www.sap.com/developer/tutorials/ci-best-practices-mobile-ios.html)  
+4.7. [SAP Cloud Platform SDK for iOS](https://www.sap.com/developer/tutorials/ci-best-practices-mobile-ios.html)
+4.8. [SAP Fiori Hybrid Apps with SAP Mobile Platform SDK](https://www.sap.com/developer/tutorials/ci-best-practices-mobile-cordova.html)
 5. CI/CD Process Setup using SCM and build services on the cloud  
 5.1. [Generic Project with CI using Cloud Services](https://www.sap.com/developer/tutorials/ci-best-practices-generic-cloud.html)  
 5.2. [Java Web on SAP Cloud Platform with CI using Cloud Services](https://www.sap.com/developer/tutorials/ci-best-practices-java-hcp-cloud.html)  


### PR DESCRIPTION
@miffels added a shiny new [tutorial](https://www.sap.com/developer/tutorials/ci-best-practices-mobile-cordova.html), but it seems we missed the link from the start page.
