### PR TITLE
we had to update all tutorials with new thing type

### DIFF
--- a/tutorials/iotae-api-postman/iotae-api-postman.md
+++ b/tutorials/iotae-api-postman/iotae-api-postman.md
@@ -103,7 +103,7 @@ Open the URL <https://sap-iotaehandson2.iot-sap.cfapps.eu10.hana.ondemand.com/ap
     |scope|Scope of the package (public, private, and tenant)|
     |services|Indicates thing service or event service|
 
-  7. You can create a thing instance for the thing type `generic_computer` in the next step.
+  7. You can create a thing instance for the thing type `generic_computer_3` in the next step.
 
     >**Note**: At rare instances, the method displays `200-OK` but without a response payload. In such scenario, ensure to redo Step 1.
 
@@ -115,12 +115,12 @@ Open the URL <https://sap-iotaehandson2.iot-sap.cfapps.eu10.hana.ondemand.com/ap
 To create data for a thing, you must identify the property set type that is used to define property sets for a thing type.	Firstly, read details of a thing type and then read details of a property set type.
 
 1. In Postman, choose the **GET** method.
-2. Enter the following request URL: `https://sap-iotaehandson2.iot-sap.cfapps.eu10.hana.ondemand.com/appiot-mds/Configuration/ThingTypes('sap.iotaehandson2.computeriotdevice:generic_computer')`
+2. Enter the following request URL: `https://sap-iotaehandson2.iot-sap.cfapps.eu10.hana.ondemand.com/appiot-mds/Configuration/ThingTypes('sap.iotaehandson2.computeriotdevice:generic_computer_3')`
 3. Click the **Send** button. Thing type details are retrieved.
 
     ```json
     {
-        "name": "sap.iotaehandson2.computeriotdevice:generic_computer",
+        "name": "sap.iotaehandson2.computeriotdevice:generic_computer_3",
         "description": {
             "en": "Generic computer"
         },
@@ -150,7 +150,7 @@ To create data for a thing, you must identify the property set type that is used
     }
     ```
 
-4. To read details of a property set type `sap.iotaehandson2.computeriotdevice:resource_sensors` defined for the thing type `sap.iotaehandson2.computeriotdevice:generic_computer`, enter the following request URL: `https://sap-iotaehandson2.iot-sap.cfapps.eu10.hana.ondemand.com/appiot-mds/Configuration/PropertySetTypes('sap.iotaehandson2.computeriotdevice:resource_sensors_2')`
+4. To read details of a property set type `sap.iotaehandson2.computeriotdevice:resource_sensors` defined for the thing type `sap.iotaehandson2.computeriotdevice:generic_computer_3`, enter the following request URL: `https://sap-iotaehandson2.iot-sap.cfapps.eu10.hana.ondemand.com/appiot-mds/Configuration/PropertySetTypes('sap.iotaehandson2.computeriotdevice:resource_sensors_2')`
 5. Click the **Send** button.
 Property set type details retrieved. You can use the property `cpu_usage` to create data for a thing.
 
@@ -214,7 +214,7 @@ Object group is a technical object used for assigning object-based authorization
     "en": "pDevice00"
 },
 "_thingType": [
-    "sap.iotaehandson2.computeriotdevice:generic_computer"
+    "sap.iotaehandson2.computeriotdevice:generic_computer_3"
 ],
 "_objectGroup": "C6484A9DC2274E4A87BCED73AAEA8650"
 }
@@ -241,7 +241,7 @@ Thing details are retrieved and displayed in the response payload.
         "en": "pDevice00"
     },
     "_thingType": [
-        "sap.iotaehandson2.computeriotdevice:generic_computer"
+        "sap.iotaehandson2.computeriotdevice:generic_computer_3"
     ],
     "_objectGroup": "C6484A9DC2274E4A87BCED73AAEA8650"
 }
@@ -254,12 +254,12 @@ Thing details are retrieved and displayed in the response payload.
 Using API endpoints is one of the ways to directly ingest data for a thing. Alternatively, using device management too you can ingest data for a thing.
 
 1. In Postman, choose the **PUT** method.
-2. Enter the following request URL: `https://sap-iotaehandson2.iot-sap.cfapps.eu10.hana.ondemand.com/appiot-mds/Things('6FD61AF611ED4357A20E2FC56B7CFB2E')/sap.iotaehandson2.computeriotdevice:generic_computer/resource_sensors_2`
+2. Enter the following request URL: `https://sap-iotaehandson2.iot-sap.cfapps.eu10.hana.ondemand.com/appiot-mds/Things('6FD61AF611ED4357A20E2FC56B7CFB2E')/sap.iotaehandson2.computeriotdevice:generic_computer_3/resource_sensors_2`
 
     | Field | Description |
     |------|--------------|
     |Thing ID|`6FD61AF611ED4357A20E2FC56B7CFB2E`|
-    |Thing Type|`sap.iotaehandson2.computeriotdevice:generic_computer`|
+    |Thing Type|`sap.iotaehandson2.computeriotdevice:generic_computer_3`|
     |Property Set|`resource_sensors_2`|
     |Property|`cpu_usage`|
 
@@ -290,7 +290,7 @@ A numeric value is created for the property `cpu_usage` with time stamp for the 
 [ACCORDION-BEGIN [Step 6: ](Read time series data)]
 1. In Postman, choose the **GET** method.
 2. Enter the following request URL:
-    `https://sap-iotaehandson2.iot-sap.cfapps.eu10.hana.ondemand.com/appiot-mds/Things('6FD61AF611ED4357A20E2FC56B7CFB2E')/sap.iotaehandson2.computeriotdevice:generic_computer/resource_sensors_2?timerange=1D`
+    `https://sap-iotaehandson2.iot-sap.cfapps.eu10.hana.ondemand.com/appiot-mds/Things('6FD61AF611ED4357A20E2FC56B7CFB2E')/sap.iotaehandson2.computeriotdevice:generic_computer_3/resource_sensors_2?timerange=1D`
     Data is requested for a time range=1 day. The other possible values are:
 
       - #M - For the specified number months

--- a/tutorials/iotae-comp-buildappmc0/iotae-comp-buildappmc0.md
+++ b/tutorials/iotae-comp-buildappmc0/iotae-comp-buildappmc0.md
@@ -65,7 +65,7 @@ Leave everything as it is on the ___Template Customization___ step. Click **Next
 
 On ___Data Source___ step select:
  - **`Freestyle-IOTAS-ADVANCEDLIST-THING-ODATA`** as a service
- - all property sets for `sap.iotaehandson2.computeriotdevice:generic_computer` thing type
+ - all property sets for `sap.iotaehandson2.computeriotdevice:generic_computer_3` thing type
 Click **Next**
 
 ![Data Source](iotaecompappmc0060.jpg)

--- a/tutorials/iotae-comp-sendpy0/iotae-comp-sendpy0.md
+++ b/tutorials/iotae-comp-sendpy0/iotae-comp-sendpy0.md
@@ -64,7 +64,7 @@ import time, sys, platform
 
 hostiotmms = 'iotmmsa2667617c.hana.ondemand.com'
 apiiotmmsdata = '/com.sap.iotservices.mms/v1/api/http/data/'
-msgtypeid = 'dc88bf65edae02a05da7'
+msgtypeid = 'd2b2db6980f940fae7d3'
 
 deviceid = '591188FC5CEF41_fake_3E9D5AE3F641429BB5'
 authtoken = '7461f8d7385_fake_179d36fcfd8'
@@ -156,7 +156,7 @@ You can find corresponding value in the output of the Python's script as well.
 [ACCORDION-BEGIN [Step 5: ](Check posted values in the API)]
 The power of SAP IoT Application Enablement is in its rich set of APIs available to build powerful customer applications on top of data from devices.
 
-E.g. to check last 5 values posted open following URL in the browser, like Chrome: <https://sap-iotaehandson2.iot-sap.cfapps.eu10.hana.ondemand.com/appiot-mds/Things('591188FC5CEF413E9D5AE3F641429BB5')/sap.iotaehandson2.computeriotdevice:generic_computer/resource_sensors_2?timerange=1H&$top=5>
+E.g. to check last 5 values posted open following URL in the browser, like Chrome: <https://sap-iotaehandson2.iot-sap.cfapps.eu10.hana.ondemand.com/appiot-mds/Things('591188FC5CEF413E9D5AE3F641429BB5')/sap.iotaehandson2.computeriotdevice:generic_computer_3/resource_sensors_2?timerange=1H&$top=5>
 
 You need to modify the thing id from `591188FC5CEF413E9D5AE3F641429BB5` to your own. Properly formatted URL will return results like this to authorized user.
 ![Values in API](iotaecomppy0040.jpg)

--- a/tutorials/iotae-comp-thingmodeler0/iotae-comp-thingmodeler0.md
+++ b/tutorials/iotae-comp-thingmodeler0/iotae-comp-thingmodeler0.md
@@ -59,10 +59,10 @@ The property `cpu_usage` is what we want to measure and has
 
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 4: ](Thing type `generic_computer`)]
+[ACCORDION-BEGIN [Step 4: ](Thing type `generic_computer_3`)]
 In the Thing Properties Catalog click on the **Thing Modeler** (the button is in the lower right corner).
 
-In the **Thing Types** pane you will see `generic_computer` thing type defined with:
+In the **Thing Types** pane you will see `generic_computer_3` (please do not use generic_computer anymore, for generic_computer ingestion is not working anymore due to a misconfiguration issue) thing type defined with:
  - Basic Data properties from the `Default` set,
  - Measured Values properties from the `resource_sensors_2` set.
 
@@ -70,7 +70,7 @@ In the **Thing Types** pane you will see `generic_computer` thing type defined w
 [ACCORDION-END]
 
 [ACCORDION-BEGIN [Step 5: ](Add your computer as a new thing)]
-From **Thing Type** overview for `generic_computer` click on the **New Thing**.
+From **Thing Type** overview for `generic_computer_3` click on the **New Thing**.
 
 ![New Thing](iotaecomptm0060.jpg)
 


### PR DESCRIPTION
this change is required due to the loss of a mapping between iot service and iot ae due to a database upgrade. with the updated md files the user should be able to get through again. as the old tutorial will not work anymore please pull this fix with priority - I'm in touch with 3 users from customer waiting for the correction.