### PR TITLE
switch steps in cp-apm-06 to avoid error in console

### DIFF
--- a/tutorials/cp-apm-06-reuse-extend/cp-apm-06-reuse-extend.md
+++ b/tutorials/cp-apm-06-reuse-extend/cp-apm-06-reuse-extend.md
@@ -126,47 +126,7 @@ In your `data-model.cds`, you will:
 
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 4: ](Add the association to the Reviews entity)]
-
-The goal is to navigate from `Products` to `Reviews`. To do this, you need to extend `Products` with an association to `Reviews`.
-
-1. In the `data-model.cds` file, add the following sample code:
-
-    ```java
-    extend Products with {
-    	Reviews: Association to many Reviews on Reviews.product = $self @title: '{i18n>review}';
-    }
-    ```
-
-    Your `data-model.cds` file should look like this:
-
-    ```java  
-    namespace SampleApp;
-
-    using clouds.products.Products from '@sap/cloud-samples-catalog';
-
-    extend Products with {
-      Reviews: Association to many Reviews on Reviews.product = $self @title: '{i18n>review}';
-    }
-
-    entity Reviews {
-      key Review: UUID;
-      product: Association to Products @title: '{i18n>product}';
-      title: String(60) @title: '{i18n>reviewTitle}';
-      message: String(1024) @title: '{i18n>reviewText}';
-      rating: Decimal(4, 2) @title: '{i18n>rating}';
-      helpfulCount: Integer @title: '{i18n>ratedHelpful}';
-      helpfulTotal: Integer @title: '{i18n>ratedTotal}';
-    }
-    ```
-
-2. Save your file.
-
-[DONE]
-
-[ACCORDION-END]
-
-[ACCORDION-BEGIN [Step 5: ](Define the service model)]
+[ACCORDION-BEGIN [Step 4: ](Define the service model)]
 
 You need to extend `CatalogService` with the view on the `Reviews` entity you added in your `data-model.cds` file.
 
@@ -200,6 +160,47 @@ You need to extend `CatalogService` with the view on the `Reviews` entity you ad
 [VALIDATE_1]
 
 [ACCORDION-END]
+
+[ACCORDION-BEGIN [Step 5: ](Add the association to the Reviews entity)]
+
+The ultimate goal is to navigate from `Products` to `Reviews`. To do this, you need to extend `Products` with an association to `Reviews`.
+
+1. Back in the `data-model.cds` file, add the following sample code:
+
+    ```java
+    extend Products with {
+    	Reviews: Association to many Reviews on Reviews.product = $self @title: '{i18n>review}';
+    }
+    ```
+
+    Your `data-model.cds` file should now look like this:
+
+    ```java  
+    namespace SampleApp;
+
+    using clouds.products.Products from '@sap/cloud-samples-catalog';
+
+    extend Products with {
+      Reviews: Association to many Reviews on Reviews.product = $self @title: '{i18n>review}';
+    }
+
+    entity Reviews {
+      key Review: UUID;
+      product: Association to Products @title: '{i18n>product}';
+      title: String(60) @title: '{i18n>reviewTitle}';
+      message: String(1024) @title: '{i18n>reviewText}';
+      rating: Decimal(4, 2) @title: '{i18n>rating}';
+      helpfulCount: Integer @title: '{i18n>ratedHelpful}';
+      helpfulTotal: Integer @title: '{i18n>ratedTotal}';
+    }
+    ```
+
+2. Save your file.
+
+[DONE]
+
+[ACCORDION-END]
+
 
 [ACCORDION-BEGIN [Step 6: ](Build the db module)]
 


### PR DESCRIPTION
There was an error appearing in the console, and the (automatic) build was failing:

```
This is CDS 2.9.1, Compiler 1.1.2, Home: node_modules/@sap/cds[ERROR] node_modules/@sap/cloud-samples-catalog/srv/cat-service.cds:42:21-38: Error: Association "clouds.products.CatalogService.Products.Reviews" cannot be implicitly redirected: Target "SampleApp.Reviews" is not exposed in service "clouds.products.CatalogService" by any projection[ERROR] node_modules/@sap/cloud-samples-foundation/common.cds:20:4-23: Warning syntax-anno-after-struct: Avoid annotation assignments after structure definitions[ERROR] node_modules/@sap/cloud-samples-foundation/common.cds:33:4-23: Warning syntax-anno-after-struct: Avoid annotation assignments after structure definitionsnpm ERR! code ELIFECYCLEnpm ERR! errno 1npm ERR! SampleApp@1.0.0 build: `cds build --clean`npm ERR! Exit status 1npm ERR! npm ERR! Failed at the SampleApp@1.0.0 build script.npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```