### PR TITLE
Updated title casing in published blockchain tutorials steps

### DIFF
--- a/tutorials/blockchain-create-hlf-node/blockchain-create-hlf-node.md
+++ b/tutorials/blockchain-create-hlf-node/blockchain-create-hlf-node.md
@@ -22,7 +22,7 @@ author_profile: https://github.com/BrianMcKellar
 
 ---
 
-[ACCORDION-BEGIN [Step 1: ](Understand the Hyperledger Fabric service)]
+[ACCORDION-BEGIN [Step 1: ](Understand the Hyperledger Fabric Service)]
 
  The Hyperledger Fabric service is integrated into SAP Cloud Platform via a service broker. The service broker supports several node types as service plans.
 
@@ -55,7 +55,7 @@ For our `Hello World` example we will be using a Development Node, with the step
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 2: ](Open the Hyperledger Fabric service)]
+[ACCORDION-BEGIN [Step 2: ](Open the Hyperledger Fabric Service)]
 
 Once on the SAP Cloud Platform Service Marketplace, locate and open the Hyperledger Fabric service by clicking the relevant service tile.
 
@@ -77,7 +77,7 @@ Click the **Instances** tab on the side menu, opening an overview of available H
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 4: ](Create new instance)]
+[ACCORDION-BEGIN [Step 4: ](Create New Instance)]
 
 Once on your Hyperledger Fabric instances overview, click **New Instance** to open the service instance wizard:
 
@@ -86,7 +86,7 @@ Once on your Hyperledger Fabric instances overview, click **New Instance** to op
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 5: ](Choose service instance settings)]
+[ACCORDION-BEGIN [Step 5: ](Choose Service Instance Settings)]
 
 Navigate through the service instance wizard, selecting the following settings:
 
@@ -104,7 +104,7 @@ After selecting the settings, click **Finish**.
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 6: ](Confirm creation of node)]
+[ACCORDION-BEGIN [Step 6: ](Confirm Creation of Node)]
 
 Your development node will now be provisioned (which may take a few moments) and displayed on the overview of available service instances.
 

--- a/tutorials/blockchain-hlf-chaincode/blockchain-hlf-chaincode.md
+++ b/tutorials/blockchain-hlf-chaincode/blockchain-hlf-chaincode.md
@@ -16,7 +16,7 @@ author_profile: https://github.com/BrianMcKellar
 
 ---
 
-[ACCORDION-BEGIN [Step 1: ](Understand chaincode)]
+[ACCORDION-BEGIN [Step 1: ](Understand Chaincode)]
 
 Hyperledger Fabric chaincode (smart contracts) control all reading and writing to a Hyperledger Fabric channel and implements all relevant business logic.
 
@@ -33,7 +33,7 @@ For this demo, we develop and deploy a simple `Hello World` chaincode that just 
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 2: ](Open the channel node dashboard)]
+[ACCORDION-BEGIN [Step 2: ](Open the Channel Node Dashboard)]
 
 To deploy and test chaincode, click the **Dashboard** icon to navigate to your channel service instance dashboard.
 
@@ -43,7 +43,7 @@ To deploy and test chaincode, click the **Dashboard** icon to navigate to your c
 [ACCORDION-END]
 
 
-[ACCORDION-BEGIN [Step 3: ](Access chaincode area)]
+[ACCORDION-BEGIN [Step 3: ](Access Chaincode Area)]
 
 Once on your channel service instance dashboard, click **Chaincode** on the side menu.
 

--- a/tutorials/blockchain-hlf-channel/blockchain-hlf-channel.md
+++ b/tutorials/blockchain-hlf-channel/blockchain-hlf-channel.md
@@ -17,7 +17,7 @@ author_profile: https://github.com/BrianMcKellar
 
 ---
 
-[ACCORDION-BEGIN [Step 1: ](Understand Hyperledger Fabric channels)]
+[ACCORDION-BEGIN [Step 1: ](Understand Hyperledger Fabric Channels)]
 
 A Hyperledger Fabric channel is created on any Hyperledger Fabric peer node and then selected peer nodes (based on permission and agreement) can join the channel. This channel is effectively one blockchain and any data written to this channel is only visible on the specific Hyperledger Fabric peer nodes attached to the channel.
 
@@ -45,7 +45,7 @@ For this demo, we will simply create the channel instance within our demo Cloud 
 [VALIDATE_1]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 2: ](Open node dashboard)]
+[ACCORDION-BEGIN [Step 2: ](Open Node Dashboard)]
 
 To create your Hyperledger Fabric channel, click the dashboard icon to navigate to your Hyperledger Fabric node dashboard.
 
@@ -54,7 +54,7 @@ To create your Hyperledger Fabric channel, click the dashboard icon to navigate 
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 3: ](Start channel creation)]
+[ACCORDION-BEGIN [Step 3: ](Start Channel Creation)]
 
 Once on your node dashboard, click **Channels** on the side menu.
 
@@ -67,7 +67,7 @@ Click **Create Channel**, opening the channel creation window.
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 4: ](Enter channel settings)]
+[ACCORDION-BEGIN [Step 4: ](Enter Channel Settings)]
 
 With the channel creation window open, enter the channel name `test-channel` and then click **Create**.
 
@@ -78,7 +78,7 @@ The channel is created and you return to the node dashboard.
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 5: ](Provision channel service instance)]
+[ACCORDION-BEGIN [Step 5: ](Provision Channel Service Instance)]
 
 Once returned to the node dashboard, click the **Service Instance** icon to provision a service instance for the channel in the same Cloud Foundry space.
 

--- a/tutorials/blockchain-navigate-cloudplatform/blockchain-navigate-cloudplatform.md
+++ b/tutorials/blockchain-navigate-cloudplatform/blockchain-navigate-cloudplatform.md
@@ -20,7 +20,7 @@ author_profile: https://github.com/BrianMcKellar
   - How to navigate to SAP Cloud Platform Service Marketplace and locate the Hyperledger Fabric service
 
 ---
-[ACCORDION-BEGIN [Step 1: ](Understand Blockchain service)]
+[ACCORDION-BEGIN [Step 1: ](Understand Blockchain Service)]
 
 On SAP Cloud Platform, different service instances are created to represent (or proxy) the real-world Hyperledger Fabric instances provisioned.
 
@@ -80,7 +80,7 @@ This gives you access to your SAP Cloud Platform cockpit.
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 4: ](Select your global account)]
+[ACCORDION-BEGIN [Step 4: ](Select your Global Account)]
 
 Once in the SAP Cloud Platform cockpit, you can access global accounts. These often represent an entire company and can be viewed as an empty shell used for billing, recording data consumption, and grouping resources together. They can't be used to directly run applications or services, however.
 
@@ -92,7 +92,7 @@ Click the global account name to open its cockpit. In this example, we are using
 [ACCORDION-END]
 
 
-[ACCORDION-BEGIN [Step 5: ](Select your sub-account)]
+[ACCORDION-BEGIN [Step 5: ](Select your Subaccount)]
 
 Once in your global account cockpit, you can access sub-accounts.
 
@@ -105,7 +105,7 @@ Click your sub-account name to open its cockpit. In this example, we are using o
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 6: ](Select your space)]
+[ACCORDION-BEGIN [Step 6: ](Select your Space)]
 
 Once in your sub-account, you can access your relevant space.
 

--- a/tutorials/blockchain-test-chaincode/blockchain-test-chaincode.md
+++ b/tutorials/blockchain-test-chaincode/blockchain-test-chaincode.md
@@ -16,7 +16,7 @@ author_profile: https://github.com/BrianMcKellar
 
 ---
 
-[ACCORDION-BEGIN [Step 1: ](Understand how applications are bound to channels)]
+[ACCORDION-BEGIN [Step 1: ](Understand how Applications are Bound to Channels)]
 
 Based on the YAML interface that describes the different chaincode functions, it is possible for the gateway to support a HTTP REST API between the chaincode and the application:
 
@@ -46,7 +46,7 @@ This opens the Swagger UI.
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 3: ](Authorize access to chaincode)]
+[ACCORDION-BEGIN [Step 3: ](Authorize Access to Chaincode)]
 
 With the Swagger UI open, click **Authorize**.
 
@@ -63,7 +63,7 @@ The Swagger UI is now authorized (shown as a closed padlock on the UI), giving y
 [VALIDATE_1]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 4: ](Invoke a transaction on chaincode)]
+[ACCORDION-BEGIN [Step 4: ](Invoke a Transaction on Chaincode)]
 
 Once authorized, click and open **POST** and then click **Try It Out**. This allows you to invoke a transaction on your chaincode:
 
@@ -88,7 +88,7 @@ The transaction will now be invoked on the chaincode, with a 200 status code dis
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 5: ](Call the chaincode)]
+[ACCORDION-BEGIN [Step 5: ](Call the Chaincode)]
 
 You can now call the chaincode using the same ID. Click **GET** and then click **Try It Out**. This allows you to call the chaincode.
 
@@ -103,7 +103,7 @@ The chaincode is now called and returns the response `Hello World!`, an indicati
 [DONE]
 [ACCORDION-END]
 
-[ACCORDION-BEGIN [Step 6: ](Explore the chaincode)]
+[ACCORDION-BEGIN [Step 6: ](Explore the Chaincode)]
 
 After successfully calling your chaincode, you can make use of the **Explore** area provided with your channel service instance.
 


### PR DESCRIPTION
Inconsistent formatting across the step titles in published blockchain tutorials / a few incorrect SAP Cloud Platform terminologies too (in particular 'sub-account'). 