### PR TITLE
[DON'T MERGE BEFORE 2019-05-06] Rename SAP S/4HANA Cloud SDK to SAP Cloud SDK in JS tutorials

### DIFF
--- a/tutorials/s4sdkjs-deploy-application-cloud-foundry/s4sdkjs-deploy-application-cloud-foundry.md
+++ b/tutorials/s4sdkjs-deploy-application-cloud-foundry/s4sdkjs-deploy-application-cloud-foundry.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy Application to Cloud Foundry with SAP S/4HANA Cloud SDK for JavaScript
+title: Deploy Application to Cloud Foundry with SAP Cloud SDK for JavaScript
 description: Deploy an existing application and deploy it to Cloud Foundry in SAP Cloud Platform.
 auto_validation: true
 time: 20

--- a/tutorials/s4sdkjs-getting-started/s4sdkjs-getting-started.md
+++ b/tutorials/s4sdkjs-getting-started/s4sdkjs-getting-started.md
@@ -1,6 +1,6 @@
 ---
-title: Get Started with SAP S/4HANA Cloud SDK for JavaScript
-description: Scaffold an application that is ready to be used with the SAP S/4HANA Cloud SDK for JavaScript.
+title: Get Started with SAP Cloud SDK for JavaScript
+description: Scaffold an application that is ready to be used with the SAP Cloud SDK for JavaScript.
 auto_validation: true
 time: 10
 tags: [ tutorial>beginner, products>sap-s-4hana-cloud-sdk, topic>javascript]
@@ -8,17 +8,18 @@ primary_tag: products>sap-s-4hana-cloud-sdk
 ---
 
 ## Details
+
 ### You will learn
- - How to scaffolded your application
+
+ - How to scaffold your application
  - About the project's structure
  - How to run the application locally
-
 
 ---
 
 [ACCORDION-BEGIN [Step 1: ](Scaffold an application)]
 
-To create an `express.js` application that already contains all the files and configuration you need to use the SAP S/4HANA Cloud SDK for JavaScript, simply clone our TypeScript scaffolding application as follows.
+To create an `express.js` application that already contains all the files and configuration you need to use the SAP Cloud SDK for JavaScript, simply clone our TypeScript scaffolding application as follows.
 
 ```Shell
 git clone --single-branch --branch scaffolding-ts --origin scaffolding https://github.com/SAP/cloud-s4-sdk-examples.git <path/to/your/project>
@@ -34,7 +35,6 @@ cd <path/to/your/project>
 
 If you cannot or do not want to use `TypeScript`, you can also checkout the `JavaScript` version. The tutorial will be based on `TypeScript`, but is easily applicable to `JavaScript`. The main differences you will notice are the type annotations and module definitions - ES6 modules in the `TypeScript` version vs. `commonJS` modules in the `JavaScript` version.
 
-
 ```Shell
 # clone the JavaScript version of the scaffolding above
 git clone --single-branch --branch scaffolding-js --origin scaffold https://github.com/SAP/cloud-s4-sdk-examples.git <path/to/your/project>
@@ -45,12 +45,12 @@ git clone --single-branch --branch scaffolding-js --origin scaffold https://gith
 
 [ACCORDION-BEGIN [Step 2: ](Get familiar with the project)]
 
-The project contains the following files and folders, among others, to get you started with the `SAP S/4HANA Cloud SDK for JavaScript`:
+The project contains the following files and folders, among others, to get you started with the `SAP Cloud SDK for JavaScript`:
 
 ### NPM / Project
 
 - **`package.json`**: Specifies dependencies, metadata and user-defined scripts. The provided scaffolding comes with some predefined scripts and dependencies, that will be explained in detail in the course of this group of tutorials.
-- **`.npmrc`**: The **`npm`** configuration file. In the scaffolding we specify the registry for the `@sap` scope, where the `SAP S/4HANA Cloud SDK` libraries are published.
+- **`.npmrc`**: The **`npm`** configuration file. In the scaffolding we specify the registry for the `@sap` scope, where the `SAP Cloud SDK` libraries are published.
 
 ### TypeScript
 
@@ -58,7 +58,7 @@ The project contains the following files and folders, among others, to get you s
 
 ### Continuous Delivery
 
-- **`Jenkinsfile`**: Jenkins pipeline definition file for quality assurance. It uses the [`SAP S/4HANA Cloud SDK's Continuous Delivery Toolkit`](https://github.com/SAP/cloud-s4-sdk-pipeline).
+- **`Jenkinsfile`**: Jenkins pipeline definition file for quality assurance. It uses the [`SAP Cloud SDK's Continuous Delivery Toolkit`](https://github.com/SAP/cloud-s4-sdk-pipeline).
 - **`pipeline_config.yml`**: Pipeline configuration file for the Jenkins pipeline.
 - **`cx-server/`**: A directory containing scripts to quickly deploy and start your own CI / CD server based on Jenkins.
 
@@ -96,16 +96,16 @@ Go to `http://localhost:8080/hello` and you should get a 'Hello, World!' in resp
 
 [ACCORDION-BEGIN [Step 4: ](Use the SDK in existing project (optional))]
 
-If you already have an existing project, you will need to specify the registry for the `@sap` scope, in order to make the `SAP S/4HANA Cloud SDK for JavaScript` libraries available. If it does not yet exist create a `.npmrc` file in the root folder of your project. Paste the following line into it:
+If you already have an existing project, you will need to specify the registry for the `@sap` scope, in order to make the `SAP Cloud SDK for JavaScript` libraries available. If it does not yet exist create a `.npmrc` file in the root folder of your project. Paste the following line into it:
 
 ```Shell
 @sap:registry=https://npm.sap.com
 ```
 
-Now you can install the necessary libraries, first of all the `@sap/s4sdk-core`, the heart of the `SAP S/4HANA Cloud SDK for JavaScript` and basis for the service libraries you might want to use.
+Now you can install the necessary libraries, first of all the `@sap/cloud-sdk-core`, the heart of the `SAP Cloud SDK for JavaScript` and basis for the service libraries you might want to use.
 
 ```Shell
-npm install @sap/s4sdk-core
+npm install @sap/cloud-sd-core
 ```
 
 We recommend to also take a look at the continuous delivery artifacts in the scaffold application and adopt those along with the respective **`npm`** scripts.
@@ -122,5 +122,3 @@ That's it! You should now have a running application that is ready to be integra
 [ACCORDION-END]
 
 ---
-
-

--- a/tutorials/s4sdkjs-getting-started/s4sdkjs-getting-started.md
+++ b/tutorials/s4sdkjs-getting-started/s4sdkjs-getting-started.md
@@ -105,7 +105,7 @@ If you already have an existing project, you will need to specify the registry f
 Now you can install the necessary libraries, first of all the `@sap/cloud-sdk-core`, the heart of the `SAP Cloud SDK for JavaScript` and basis for the service libraries you might want to use.
 
 ```Shell
-npm install @sap/cloud-sd-core
+npm install @sap/cloud-sdk-core
 ```
 
 We recommend to also take a look at the continuous delivery artifacts in the scaffold application and adopt those along with the respective **`npm`** scripts.

--- a/tutorials/s4sdkjs-odata-service-cloud-foundry/s4sdkjs-odata-service-cloud-foundry.md
+++ b/tutorials/s4sdkjs-odata-service-cloud-foundry/s4sdkjs-odata-service-cloud-foundry.md
@@ -1,6 +1,6 @@
 ---
-title: Create Your First Application with SAP S/4HANA Cloud SDK for JavaScript
-description: Learn the fundamentals of the SAP S/4HANA Cloud SDK for JavaScript and integrate with an SAP S/4HANA Cloud system.
+title: Create Your First Application with SAP Cloud SDK for JavaScript
+description: Learn the fundamentals of the SAP Cloud SDK for JavaScript and integrate with an SAP S/4HANA Cloud system.
 auto_validation: true
 time: 10
 tags: [ tutorial>beginner, products>sap-s-4hana-cloud-sdk, topic>javascript]
@@ -10,7 +10,7 @@ primary_tag: products>sap-s-4hana-cloud-sdk
 ## Details
 ### You will learn
  - How to extend a scaffolded application by another route
- - How to call the Business Partner Service of SAP S/4HANA Cloud using SAP S/4HANA Cloud SDK for JavaScript
+ - How to call the Business Partner Service of SAP S/4HANA Cloud using SAP Cloud SDK for JavaScript
 
 ---
 
@@ -68,7 +68,7 @@ You can start your application by running `npm run start:local`. Now, calling `h
 
 [ACCORDION-BEGIN [Step 3: ](Import service entities)]
 
-In order to use the `SAP S/4HANA Cloud SDK for JavaScript` to make a call to an `OData` service add the `virtual data model` (`VDM`) for this service to your dependencies. For this tutorial we are using the `VDM` for the business partner service. Install it with the following:
+In order to use the `SAP Cloud SDK for JavaScript` to make a call to an `OData` service add the `virtual data model` (`VDM`) for this service to your dependencies. For this tutorial we are using the `VDM` for the business partner service. Install it with the following:
 
 ```Shell
 npm install @sap/cloud-sdk-vdm-business-partner-service
@@ -82,7 +82,7 @@ import { BusinessPartner } from '@sap/cloud-sdk-vdm-business-partner-service';
 
 Now the `BusinessPartner` entity is available for you to be used.
 
->**Side-note:** The `SAP S/4HANA Cloud SDK for JavaScript` offers packages for each `OData` service exposed by `SAP S/4HANA Cloud`. You can find a list of these services in the [`SAP API Business Hub`](https://api.sap.com/package/SAPS4HANACloud?section=Artifacts) and a list of the corresponding packages in our [documentation](https://help.sap.com/doc/9dbcab0600b346c2b359a8c8978a45ba/1.0/en-US/index.html).
+>**Side-note:** The `SAP Cloud SDK for JavaScript` offers packages for each `OData` service exposed by `SAP S/4HANA Cloud`. You can find a list of these services in the [`SAP API Business Hub`](https://api.sap.com/package/SAPS4HANACloud?section=Artifacts) and a list of the corresponding packages in our [documentation](https://help.sap.com/doc/9dbcab0600b346c2b359a8c8978a45ba/1.0/en-US/index.html).
 
 [DONE]
 [ACCORDION-END]
@@ -145,7 +145,7 @@ function getAllBusinessPartners(): Promise<BusinessPartner[]> {
 
 Now restart your server and reload the `http://localhost:8080/business-partners` ` url`  to retrieve a list of business partners.
 
-Congratulations, you just made your first call with the SAP S/4HANA Cloud SDK!
+Congratulations, you just made your first call with the SAP Cloud SDK!
 
 [DONE]
 [ACCORDION-END]

--- a/tutorials/s4sdkjs-prerequisites/s4sdkjs-prerequisites.md
+++ b/tutorials/s4sdkjs-prerequisites/s4sdkjs-prerequisites.md
@@ -1,6 +1,6 @@
 ---
-title: Get Set to Use SAP S/4HANA Cloud SDK for JavaScript
-description: Set up your environment to use SAP S/4HANA Cloud SDK for JavaScript.
+title: Get Set to Use SAP Cloud SDK for JavaScript
+description: Set up your environment to use SAP Cloud SDK for JavaScript.
 auto_validation: true
 time: 10
 tags: [ tutorial>beginner, products>sap-s-4hana-cloud-sdk, topic>javascript]


### PR DESCRIPTION
On May 6th, we're officially renaming the "SAP S/4HANA Cloud SDK" to "SAP Cloud SDK".
This PR addresses this for the tutorials about the SAP Cloud SDK for JavaScript.
This is done in correspondenence with @karstenmelato .

Please note that there's still a tag `products>sap-s-4hana-cloud-sdk` that should probably be renamed (which would then have to be reflected in the tutorials, of course).