### PR TITLE
Fix Tutorial Link Detecting

### DIFF
--- a/test-tool/src/checkers/content-checker.js
+++ b/test-tool/src/checkers/content-checker.js
@@ -147,7 +147,7 @@ module.exports = {
         }
       }
 
-      const stepName = line.startsWith('[ACCORDION');
+      const stepName = line.includes('[ACCORDION');
 
       if (tutorialLinkMatch && !stepName) {
         const [, tutorialName] = tutorialLinkMatch[0]


### PR DESCRIPTION
Fixes `[Step : ](XXXXX)` being considered as a link to a tutorial in the md like the following:

```

<!-- [ACCORDION-BEGIN [Step : ](XXXXX)]
467
[DONE]
468
[ACCORDION-END] -->
```