### PR TITLE
Searching for express edition doesn't show right results

### DIFF
--- a/tutorials/hxe-ua-install-using-docker-xsa/hxe-ua-install-using-docker-xsa.md
+++ b/tutorials/hxe-ua-install-using-docker-xsa/hxe-ua-install-using-docker-xsa.md
@@ -123,7 +123,7 @@ sudo docker image rm alpine -f
 
 Go to the [Docker Store](https://store.docker.com/).
 
-Click on the search bar and search for "SAP HANA, express edition".
+Click on the search bar and search for "SAP HANA, express".
 
 Choose **SAP HANA, express edition (database and application services)**.
 

--- a/tutorials/hxe-ua-install-using-docker/hxe-ua-install-using-docker.md
+++ b/tutorials/hxe-ua-install-using-docker/hxe-ua-install-using-docker.md
@@ -94,7 +94,7 @@ sudo docker image rm alpine -f
 
 Go to the [Docker Store](https://store.docker.com/).
 
-Click on the search bar and search for "SAP HANA, express edition".
+Click on the search bar and search for "SAP HANA, express".
 
 Choose **SAP HANA, express edition (database services)**.
 


### PR DESCRIPTION
Searching on `hub.docker.com` for `SAP HANA, express edition` will show
DB systems from different vendors. By removing `edition` this is fixed.

Fixes #3526