### PR TITLE
Replace main parts bullet list with numbered list

### DIFF
--- a/tutorials/datahub-docker-v2-examples/datahub-docker-v2-examples.md
+++ b/tutorials/datahub-docker-v2-examples/datahub-docker-v2-examples.md
@@ -24,10 +24,10 @@ Open the modelling environment for building pipelines via `http://localhost:8090
 
 The modelling environment consists of four main parts:
 
-  - **Navigation**: You use this part of the modelling environment to access pipelines (also known as graphs), operators and the repository.
-  - **Pipeline editor**: You create and edit pipelines here.
-  - **Configuration / documentation**: You use this part of the modelling environment to configure pipelines as well as operators inside pipelines and to access the documentation. The two buttons on the right help you to switch between configuration and documentation.
-  - **Status messages, logs, traces**: You use this part of the modelling environment to monitor the execution of pipelines.
+  1. **Navigation**: You use this part of the modelling environment to access pipelines (also known as graphs), operators and the repository.
+  2. **Pipeline editor**: You create and edit pipelines here.
+  3. **Configuration / documentation**: You use this part of the modelling environment to configure pipelines as well as operators inside pipelines and to access the documentation. The two buttons on the right help you to switch between configuration and documentation.
+  4. **Status messages, logs, traces**: You use this part of the modelling environment to monitor the execution of pipelines.
 
 [DONE]
 


### PR DESCRIPTION
Given that the image above has numbers, it is more user-friendly if a numbered list is used instead of a bullet list. By using numbers, the reader can easily match sections with descriptions in the list.