### PR TITLE
Fix cp-java-reference-app-document-service completion tags

### DIFF
--- a/tutorials/cp-java-reference-app-document-service/cp-java-reference-app-document-service.md
+++ b/tutorials/cp-java-reference-app-document-service/cp-java-reference-app-document-service.md
@@ -166,6 +166,7 @@ This file will read properties from `config.properties` for the document service
       Package: `com.sap.espm.model.util`
 
       Use [the following code](https://github.com/SAP/cloud-espm-v2/blob/master/espm-cloud-web/src/main/java/com/sap/espm/model/util/ReadProperties.java) to implement the class.
+
 [DONE]
 [ACCORDION-END]
 


### PR DESCRIPTION
Completion tag for step 4 is incorrectly placed, thus it is not possible for trainees to set tutorial status as completed.