### PR TITLE
Updates SAP Cloud Platform trial cockpit URL

### DIFF
--- a/tutorials/angular-add-odata/angular-add-odata.md
+++ b/tutorials/angular-add-odata/angular-add-odata.md
@@ -4,7 +4,7 @@ description: OData is our backend data source.  Connect to the public Northwind 
 primary_tag: topic>html5
 tags: [  tutorial>beginner, topic>html5, topic>mobile, topic>odata, products>sap-cloud-platform ]
 ---
-## Prerequisites  
+## Prerequisites
  - **Proficiency:** Beginner
  - **Tutorials** [Separate the JavaScript and CSS Files](https://developers.sap.com/tutorials/angular-separate-files.html)
 
@@ -12,7 +12,7 @@ tags: [  tutorial>beginner, topic>html5, topic>mobile, topic>odata, products>sap
  - **Tutorials** [Add a Header and Detail Modal Dialog](https://developers.sap.com/tutorials/angular-add-header-detail-dialog.html)
 
 ## Details
-### You will learn  
+### You will learn
 In this tutorial series, we will explore another technology for Single Page Application (SPA) development - AngularJS (or just Angular).  Angular is a popular web framework in North America, and is used by many companies for both internal and client-facing systems.  These tutorials will parallel our SAPUI5 tutorials, building a visual interface using Angular, and connecting it to an OData back end service.
 
 ### Time to Complete
@@ -24,7 +24,7 @@ Start to work with the `$http` service.  This service provides a way to asynchro
 
 We need to do two things to make this work:
 
-1. Set up a destination to the [Northwind OData reference service](http://www.odata.org/odata-services/).  
+1. Set up a destination to the [Northwind OData reference service](http://www.odata.org/odata-services/).
 2. Remove our static data, and connect to this destination.
 
 ---
@@ -35,7 +35,7 @@ We need to do two things to make this work:
 >
 > If you have not configured the Northwind destination in SAP Cloud Platform, you must do that first.  To verify that you have configured SAP Cloud Platform correctly, do the following:
 >
-> - Open a new browser page to the **[SAP Cloud Platform Cockpit](https://account.hanatrial.ondemand.com/cockpit)**
+> - Open a new browser page to the **[SAP Cloud Platform Cockpit](https://cockpit.hanatrial.ondemand.com/cockpit)**
 > - In the right hand navigation, select *Connectivity*, then select *Destinations*
 > - Look for the Destination called `Northwind`.
 >
@@ -84,7 +84,7 @@ We need to do two things to make this work:
 
     >Don't forget to save your file.
 
-    ![delete the test data](1-1.png)   
+    ![delete the test data](1-1.png)
 
 2.  Change the line that defines the `productList` to start with an empty array.
 
@@ -94,9 +94,9 @@ We need to do two things to make this work:
     $scope.productList = [];
     ```
 
-    ![Reset the product list to an empty array](1-2.png)   
+    ![Reset the product list to an empty array](1-2.png)
 
-3.  Now we want to add in the HTML call to get the OData information.  To do that, we will use the `$http` service to get the data.  
+3.  Now we want to add in the HTML call to get the OData information.  To do that, we will use the `$http` service to get the data.
 
     Change the `helloController` function to get the `$http` service from Angular
 
@@ -104,9 +104,9 @@ We need to do two things to make this work:
     function helloController($scope, $http) {
     ```
 
-    ![Get the $http controller from Angular](1-3.png)   
+    ![Get the $http controller from Angular](1-3.png)
 
-4.  Now, add in the `$get` method.  
+4.  Now, add in the `$get` method.
 
     Update your `helloController` function and add this code at the bottom:
 
@@ -123,11 +123,11 @@ We need to do two things to make this work:
     );
     ```
 
-    ![Make an OData request](1-4b.png)   
+    ![Make an OData request](1-4b.png)
 
 5.  Run your application.  The data on the screen should now contain 20 rows, and look like this:
 
-    ![Display the live OData on the screen](1-5.png)   
+    ![Display the live OData on the screen](1-5.png)
 
 
 ## Additional Information
@@ -143,13 +143,13 @@ We need to do two things to make this work:
 
 #### Using SAP Cloud Platform Destinations
 
-The sample application uses the [SAP Cloud Platform (HCP) destinations](https://help.hana.ondemand.com/help/frameset.htm?e4f1d97cbb571014a247d10f9f9a685d.html) to access the sample data.  
+The sample application uses the [SAP Cloud Platform (HCP) destinations](https://help.hana.ondemand.com/help/frameset.htm?e4f1d97cbb571014a247d10f9f9a685d.html) to access the sample data.
 
 We do this using the `neo-app.json` file.  This is the [Application Descriptor File](https://help.hana.ondemand.com/help/frameset.htm?aed1ffa3f3e741b3a4573c9e475aa2a4.html), and can be used to configure your application running inside HCP.
 
 **Why doesn't the sample application just connect directly to the OData test service?**
 
-Normally, you can do this.  In fact, it's the recommended method.  But we are working around a bug.  
+Normally, you can do this.  In fact, it's the recommended method.  But we are working around a bug.
 
 There are two things happening here.  First, all the major web browsers prevent you from loading insecure data in to a secure page.  That is called [Mixed Content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content).  If the original web page is secure, the browser will demand all data is secure as well.  So, the browser automatically uses HTTPS connections for all data.
 

--- a/tutorials/angular-getting-started/angular-getting-started.md
+++ b/tutorials/angular-getting-started/angular-getting-started.md
@@ -4,7 +4,7 @@ description: Get started writing a simple AngularJS application.
 primary_tag: topic>html5
 tags: [  tutorial>beginner, topic>html5, topic>mobile, topic>odata, products>sap-cloud-platform ]
 ---
-## Prerequisites  
+## Prerequisites
  - **Proficiency:** Beginner
  - **Tutorials:** You will need a SAP Cloud Platform (HCP) trial account for this tutorial series.  [Create an SAP Cloud Platform trial Account](https://developers.sap.com/tutorials/hcp-create-trial-account.html)
 
@@ -13,7 +13,7 @@ tags: [  tutorial>beginner, topic>html5, topic>mobile, topic>odata, products>sap
  - **Tutorials:** [Create the Bootstrap Template](https://developers.sap.com/tutorials/angular-bootstrap-template.html)
 
 ## Details
-### You will learn  
+### You will learn
 In this tutorial series, we will explore another technology for Single Page Application (SPA) development - AngularJS (or just Angular).  Angular is a popular web framework in North America, and is used by many companies for both internal and client-facing systems.  These tutorials will parallel our SAPUI5 tutorials, building a visual interface using Angular, and connecting it to an OData back end service.
 
 ### Time to Complete
@@ -27,13 +27,13 @@ Connect to the SAP Web IDE (free for development use), and then get a simple pro
 
 ### Connect to SAP Web IDE
 
-1.  Open your SAP Cloud Platform account (if you have a free developer account, click [HERE](https://account.hanatrial.ondemand.com/) to open the console.)
+1.  Open your SAP Cloud Platform account (if you have a free developer account, click [HERE](https://cockpit.hanatrial.ondemand.com/) to open the console.)
 
     >**Trouble logging in?** If you have trouble logging in to your SAP Cloud Platform Cockpit, and you are using a company account (one provided by your employer), it is possible that the Cloud access has been locked.  Create a new FREE trial account by clicking the link above, and use your personal email address to set up the new account.
 
     ![SAP Cloud Platform Developer Account Login Screen](1-1.png)
 
-2.  You should now be in the SAP Cloud Platform Cockpit, as shown below.  Click on the **Services** menu item on the left.  
+2.  You should now be in the SAP Cloud Platform Cockpit, as shown below.  Click on the **Services** menu item on the left.
 
     Next, click on the **SAP Web IDE** box.  You may need to scroll down to find this box.
 

--- a/tutorials/blockchain-navigate-cloudplatform/blockchain-navigate-cloudplatform.md
+++ b/tutorials/blockchain-navigate-cloudplatform/blockchain-navigate-cloudplatform.md
@@ -39,7 +39,7 @@ SAP's blockchain services are available in SAP Cloud Platform's Cloud Foundry en
 
 For further details about trial accounts, read the SAP Cloud Platform [documentation](https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/8ed4a705efa0431b910056c0acdbf377.html#046f127f2a614438b616ccfc575fdb16.html)
 
-To register for a trial account, navigate to SAP Cloud Platform [trial page](https://account.hanatrial.ondemand.com/#/home/welcome) and click **Register**.
+To register for a trial account, navigate to SAP Cloud Platform [trial page](https://cockpit.hanatrial.ondemand.com/) and click **Register**.
 
 ![Image depicting SAP cloud platform trial page](01--TrialPage.png)
 

--- a/tutorials/cp-apim-openconnectors-connect-hubspot/cp-apim-openconnectors-connect-hubspot.md
+++ b/tutorials/cp-apim-openconnectors-connect-hubspot/cp-apim-openconnectors-connect-hubspot.md
@@ -39,7 +39,7 @@ primary_tag: products>sap-api-management
 
 [ACCORDION-BEGIN [Step 2: ](Connect to third-party application)]
 
-1. Log on to your [SAP Cloud Platform trial](https://account.hanatrial.ondemand.com/).
+1. Log on to your [SAP Cloud Platform trial](https://cockpit.hanatrial.ondemand.com/).
 
     - Navigate to the **Cloud Foundry** environment by clicking on **Enter Your Trial Account** and click on **trial**.
 

--- a/tutorials/cp-azure-ad-saml/cp-azure-ad-saml.md
+++ b/tutorials/cp-azure-ad-saml/cp-azure-ad-saml.md
@@ -24,7 +24,7 @@ You will enable trust between SAP Cloud Platform Cloud Foundry subaccount and yo
 >Note:
 > Your Azure Portal might look different according to your configured colour scheme. You can change your colour scheme whenever you want in the portal settings section.
 
-Navigate to your SAP Cloud Platform Cloud Foundry subaccount in the [SAP Cloud Platform cockpit](https://account.hanatrial.ondemand.com/cockpit/#/home/trialhome) in order to have your `tenant` and `region` values for the next step handy.
+Navigate to your SAP Cloud Platform Cloud Foundry subaccount in the [SAP Cloud Platform cockpit](https://cockpit.hanatrial.ondemand.com/cockpit/) in order to have your `tenant` and `region` values for the next step handy.
 
 ![tenant and region replacement](tenant-region-replacement.png)
 

--- a/tutorials/cp-cf-businessrules01-enable-br/cp-cf-businessrules01-enable-br.md
+++ b/tutorials/cp-cf-businessrules01-enable-br/cp-cf-businessrules01-enable-br.md
@@ -21,7 +21,7 @@ You can create a service instance of business rules to get started with SAP Clou
 
 [ACCORDION-BEGIN [Step 1: ](Open SAP Cloud Platform cockpit)]
 
-1. In your Web browser, open the [SAP Cloud Platform](https://account.hanatrial.ondemand.com/cockpit) cockpit. If you do not have a trial account, see Prerequisites.
+1. In your Web browser, open the [SAP Cloud Platform](https://cockpit.hanatrial.ondemand.com/cockpit) cockpit. If you do not have a trial account, see Prerequisites.
 
 2. Choose **Enter Your Trial Account**.
 
@@ -38,7 +38,7 @@ You can create a service instance of business rules to get started with SAP Clou
 
 2. Navigate to **Spaces** and then choose your space.
 
-    ![choose spaces](enablebr-2.PNG)   
+    ![choose spaces](enablebr-2.PNG)
 
 3. In the navigation area, choose **Service** > **Service Marketplace** and then choose **Business Rules** tile.
 

--- a/tutorials/cp-cf-processvisibility-setup-assignroles/cp-cf-processvisibility-setup-assignroles.md
+++ b/tutorials/cp-cf-processvisibility-setup-assignroles/cp-cf-processvisibility-setup-assignroles.md
@@ -22,7 +22,7 @@ Add roles to one or more role collections and then assign these role collections
 
 [ACCORDION-BEGIN [Step 1: ](Create a role collection)]
 
-1. In your Web browser, open the [SAP Cloud Platform](https://account.hanatrial.ondemand.com/cockpit) cockpit. If you do not have a trial account, see Prerequisites.
+1. In your Web browser, open the [SAP Cloud Platform](https://cockpit.hanatrial.ondemand.com/cockpit) cockpit. If you do not have a trial account, see Prerequisites.
 
 2. You will see two buttons on the welcome screen of the SAP Cloud Platform Cockpit. Click on **Enter Your Trial Account** to see your global account.
 

--- a/tutorials/cp-cf-processvisibility-setup-serviceinstance/cp-cf-processvisibility-setup-serviceinstance.md
+++ b/tutorials/cp-cf-processvisibility-setup-serviceinstance/cp-cf-processvisibility-setup-serviceinstance.md
@@ -22,7 +22,7 @@ You must create a service instance to enable SAP Cloud Platform Process Visibili
 
 [ACCORDION-BEGIN [Step 1: ](Open the SAP Cloud Platform cockpit)]
 
-1. In your Web browser, open the [SAP Cloud Platform](https://account.hanatrial.ondemand.com/cockpit) cockpit. If you do not have a trial account, see Prerequisites.
+1. In your Web browser, open the [SAP Cloud Platform](https://cockpit.hanatrial.ondemand.com/cockpit) cockpit. If you do not have a trial account, see Prerequisites.
 
 2. You will see two buttons on the welcome screen of the SAP Cloud Platform Cockpit. Click on **Enter Your Trial Account** to see your global account.
 

--- a/tutorials/cp-cf-rabbitmq-create-service/cp-cf-rabbitmq-create-service.md
+++ b/tutorials/cp-cf-rabbitmq-create-service/cp-cf-rabbitmq-create-service.md
@@ -7,12 +7,12 @@ tags: [ tutorial>beginner, products>sap-cloud-platform, topic>cloud , topic>java
 time: 10
 ---
 
-## Prerequisites  
+## Prerequisites
  - [Sign up for a free trial account on SAP Cloud Platform](hcp-create-trial-account)
  - [Install the Cloud Foundry Command Line Interface](cp-cf-download-cli)
 
 ##Details
-### You will learn  
+### You will learn
   - How to find a service in the SAP Cloud Platform Cloud Service marketplace
   - How to use the SAP Cloud Platform cockpit
   - How to use the Cloud Foundry CLI
@@ -60,7 +60,7 @@ time: 10
 
 [ACCORDION-BEGIN [Step: ](Navigate to the service marketplace)]
 
-Log onto the [SAP Cloud Platform](https://account.hanatrial.ondemand.com/) and enter the Cloud Foundry (Trial) environment.
+Log onto the [SAP Cloud Platform](https://cockpit.hanatrial.ondemand.com/) and enter the Cloud Foundry (Trial) environment.
 
 ![start](./trial-start.png)
 

--- a/tutorials/cp-connectivity-create-secure-tunnel-neo/cp-connectivity-create-secure-tunnel-neo.md
+++ b/tutorials/cp-connectivity-create-secure-tunnel-neo/cp-connectivity-create-secure-tunnel-neo.md
@@ -7,12 +7,12 @@ tags: [  tutorial>beginner, products>sap-cloud-platform, products>sap-cloud-plat
 time: 15
 ---
 
-## Prerequisites  
+## Prerequisites
   - [Install the Cloud Connector in your System Landscape](https://developers.sap.com/tutorials/cp-connectivity-install-cloud-connector.html)
   - [Get a Free Trial Account on SAP Cloud Platform (Neo)](https://developers.sap.com/tutorials/hcp-create-trial-account.html)
 
 ## Details
-### You will learn  
+### You will learn
 - How to connect the Cloud Connector to your trial Neo account on SAP Cloud Platform
 - How to connect the Cloud Connector to your ABAP system
 
@@ -22,7 +22,7 @@ time: 15
 
 Before you can access data from the Cloud Connector in an application on SAP Cloud Platform (Neo), you must establish a trust between your SAP Cloud Platform subaccount and the Cloud Connector that is installed in your system landscape.
 
-1. Go to [Your SAP Cloud Platform Trial](https://account.hanatrial.ondemand.com/cockpit) | **Neo Trial**, and navigate to your subaccount.
+1. Go to [Your SAP Cloud Platform Trial](https://cockpit.hanatrial.ondemand.com/cockpit) | **Neo Trial**, and navigate to your subaccount.
 
 1. Copy your technical subaccount name from the title to a local text editor:
 
@@ -133,7 +133,7 @@ Before applications on SAP Cloud Platform can access any services of the ABAP sy
 
     ![Access-Control-OP](step-03-Configure-OP-Connection-012.png)
 
-As a result, you now have configured a secure tunnel between your ABAP system and your Neo subaccount on SAP Cloud Platform.  
+As a result, you now have configured a secure tunnel between your ABAP system and your Neo subaccount on SAP Cloud Platform.
 
 [VALIDATE_3]
 

--- a/tutorials/cp-connectivity-create-secure-tunnel/cp-connectivity-create-secure-tunnel.md
+++ b/tutorials/cp-connectivity-create-secure-tunnel/cp-connectivity-create-secure-tunnel.md
@@ -7,12 +7,12 @@ tags: [  tutorial>beginner, products>sap-cloud-platform, products>sap-cloud-plat
 time: 15
 ---
 
-## Prerequisites  
+## Prerequisites
   - [Configure your ABAP System to Activate OData Services of Fiori Reference Apps](https://developers.sap.com/tutorials/cp-connectivity-configure-fiori-reference-apps.html)
   - [Install the Cloud Connector in your System Landscape](https://developers.sap.com/tutorials/cp-connectivity-install-cloud-connector.html)
 
 ## Details
-### You will learn  
+### You will learn
   - How to connect the Cloud Connector to your trial cloud foundry account on SAP Cloud Platform
   - How to connect the Cloud Connector to your ABAP system
 
@@ -23,7 +23,7 @@ time: 15
 
 Before you can access data from the Cloud Connector in an application on SAP Cloud Platform, you must establish a trust between your SAP Cloud Platform subaccount and the Cloud Connector that is installed in your system landscape. To do so, you need your subaccount ID.
 
-1. Go to [Your SAP Cloud Platform Trial](https://account.hanatrial.ondemand.com/cockpit) | **Cloud Foundry Trial**, and navigate to your subaccount.
+1. Go to [Your SAP Cloud Platform Trial](https://cockpit.hanatrial.ondemand.com/cockpit) | **Cloud Foundry Trial**, and navigate to your subaccount.
 
 1. The card with your subaccount information will show the sub-account name **trial** by default. If the card shows the subdomain instead of your subaccount's ID choose the flip icon:
 
@@ -133,7 +133,7 @@ Before applications on SAP Cloud Platform can access any services of the ABAP sy
 
     ![Access-Control-OP](step-03-Configure-OP-Connection-012.png)
 
-As a result, you now have configured a secure tunnel between your ABAP system and your subaccount on SAP Cloud Platform.  
+As a result, you now have configured a secure tunnel between your ABAP system and your subaccount on SAP Cloud Platform.
 
 [VALIDATE_3]
 

--- a/tutorials/cp-enable-essential-neo-services/cp-enable-essential-neo-services.md
+++ b/tutorials/cp-enable-essential-neo-services/cp-enable-essential-neo-services.md
@@ -18,7 +18,7 @@ time: 5
 
 [ACCORDION-BEGIN [Step 1: ](Navigate to the services section)]
 
-In the Neo environment, you enable services in the SAP Cloud Platform cockpit.  From the [SAP Cloud Platform Trial welcome page](https://account.hanatrial.ondemand.com/#/home/welcome) homepage select the Neo tile.
+In the Neo environment, you enable services in the SAP Cloud Platform cockpit.  From the [SAP Cloud Platform Trial welcome page](https://cockpit.hanatrial.ondemand.com) homepage scroll down and select the Neo environment.
 
 ![Neo Access](neo-access.png)
 

--- a/tutorials/cp-explore-cloud-platform/cp-explore-cloud-platform.md
+++ b/tutorials/cp-explore-cloud-platform/cp-explore-cloud-platform.md
@@ -9,11 +9,11 @@ tags: [ tutorial>beginner, topic>cloud, products>sap-cloud-platform ]
 time: 15
 ---
 
-## Prerequisites  
+## Prerequisites
  - There are none. If you want to start learning about SAP Cloud Platform, this is the very beginning.
 
 ## Details
-### You will learn  
+### You will learn
   - What is SAP Cloud Platform?
   - What do SaaS, PaaS, and IaaS mean and how do they work?
   - What are services, and where can I find out about them?
@@ -25,7 +25,7 @@ time: 15
 
 **Welcome to the SAP Cloud Platform**
 
-SAP Cloud Platform is an open set of Software, Platform, and Infrastructure as a Service systems that delivers in-memory capabilities, core platform services, and unique micro-services for building and extending intelligent, mobile and browser enabled applications.  SAP Cloud Platform is multi-lingual, with support for most major languages ([now including ABAP](https://blogs.sap.com/2018/09/04/sap-cloud-platform-abap-environment/)) and support for development, testing, and production systems both inside an organization and to the larger public.  
+SAP Cloud Platform is an open set of Software, Platform, and Infrastructure as a Service systems that delivers in-memory capabilities, core platform services, and unique micro-services for building and extending intelligent, mobile and browser enabled applications.  SAP Cloud Platform is multi-lingual, with support for most major languages ([now including ABAP](https://blogs.sap.com/2018/09/04/sap-cloud-platform-abap-environment/)) and support for development, testing, and production systems both inside an organization and to the larger public.
 
 SAP Cloud Platform provides a large number of SAP software packages, or services, that deliver all the functionality of on-premise SAP applications, but in a cloud focused way.  It also provides a way for developers to customize those services, or build entirely new applications, to deliver custom applications personalized to your organization.
 
@@ -63,13 +63,13 @@ The three different service levels are:
 
 [ACCORDION-BEGIN [Step](SAP Cloud Platform service types)]
 
-SAP Cloud Platform provides both Platform as a Service (PaaS) and Software as a Service (SaaS).  
+SAP Cloud Platform provides both Platform as a Service (PaaS) and Software as a Service (SaaS).
 
-Why does SAP provide both?  The combination of both PaaS and SaaS provide all the tools we have traditionally sold, new tools that are specific to the cloud, and also the ability to customize all of our products to fit each individual organization.  
+Why does SAP provide both?  The combination of both PaaS and SaaS provide all the tools we have traditionally sold, new tools that are specific to the cloud, and also the ability to customize all of our products to fit each individual organization.
 
 We have a lot of SaaS solutions available in the SAP Cloud.  They include our core package, S/4HANA, as well as Workflow, Human Resources, and new products like Internet of Things.  There are many more in the list, so [take a look at a more complete list for details](https://cloudplatform.sap.com/support/service-description.html).
 
-> **Note**:  There are two different types of Services being described here.  The software listed above are stand-alone software packages, which can be used without customization.  These are all Software as a Service, but we refer to those applications as **Solutions**.  
+> **Note**:  There are two different types of Services being described here.  The software listed above are stand-alone software packages, which can be used without customization.  These are all Software as a Service, but we refer to those applications as **Solutions**.
 >
 > SAP Cloud Platform also offers services, called "Platform Services", which provide additional functionality to custom code. These "Platform Services" do not run independently.  SAP refers to these as **Services**, especially in Cloud Foundry.  So when you see the name "Service" in later tutorials, this usually means "Platform Services".
 
@@ -114,11 +114,11 @@ Which environment is right for you?  That's a good question.  Each environment h
 
 [ACCORDION-BEGIN [Step](SAP Cloud Foundry cockpit)]
 
-Accessing SAP Cloud Foundry starts with the [SAP Cloud Platform cockpit](https://account.hanatrial.ondemand.com/register) .
+Accessing SAP Cloud Foundry starts with the [SAP Cloud Platform cockpit](https://cockpit.hanatrial.ondemand.com/cockpit) .
 
 ![Image of the cockpit landing page](cockpit-main.png)
 
-Developers can access the SAP Cloud Platform cockpits to log in and access both PaaS and SaaS systems in the cloud.  
+Developers can access the SAP Cloud Platform cockpits to log in and access both PaaS and SaaS systems in the cloud.
 
 > Bookmark the link for fast and quick access to the cockpit.  
 >&nbsp;
@@ -131,9 +131,9 @@ Developers can access the SAP Cloud Platform cockpits to log in and access both 
 
 [ACCORDION-BEGIN [Step](Trial accounts on SAP Cloud Platform)]
 
-SAP offers a [free trial of SAP Cloud Platform](https://account.hanatrial.ondemand.com/register).  Both the Neo and Cloud Foundry environments are available for trial.  
+SAP offers a [free trial of SAP Cloud Platform](https://cockpit.hanatrial.ondemand.com/cockpit).  Both the Neo and Cloud Foundry environments are available for trial.
 
-The Neo environment is a lifetime free trial, and never expires.  
+The Neo environment is a lifetime free trial, and never expires.
 
 ![Neo environment starting page](neo-environment.png)
 
@@ -148,7 +148,7 @@ Later tutorials will describe how to create accounts for both Neo and Cloud Foun
 
 [ACCORDION-BEGIN [Step](Accounts and Sub-Accounts)]
 
-SAP Cloud Platform uses two levels of accounts:  Global Accounts, and Sub-Accounts.  
+SAP Cloud Platform uses two levels of accounts:  Global Accounts, and Sub-Accounts.
 
 A Global Account is the primary account for your organization or team.  It is the central pool of all the resources.  The Global Account isn't accessed directly, it just acts as an "umbrella" or container for all of the Sub-Accounts.
 

--- a/tutorials/cp-mlf-create-instance/cp-mlf-create-instance.md
+++ b/tutorials/cp-mlf-create-instance/cp-mlf-create-instance.md
@@ -21,7 +21,7 @@ primary_tag: products>sap-leonardo-machine-learning-foundation
 
 Access the SAP Cloud Platform Cockpit and login if necessary:
 
- - <https://account.hanatrial.ondemand.com/cockpit#/home/trialhome>
+ - <https://cockpit.hanatrial.ondemand.com/cockpit>
 
 Select the **Cloud Foundry Trial**.
 

--- a/tutorials/cp-osba-azure-deploy-service-broker/cp-osba-azure-deploy-service-broker.md
+++ b/tutorials/cp-osba-azure-deploy-service-broker/cp-osba-azure-deploy-service-broker.md
@@ -20,7 +20,7 @@ In the following steps, you will deploy the Azure service broker application to 
 
 [ACCORDION-BEGIN [Step 1: ](Set the right API endpoint)]
 
-To log onto the right SAP Cloud Platform Cloud Foundry endpoint, the right API endpoint URL is needed. Therefore, log into the [SAP Cloud Platform cockpit](https://account.hanatrial.ondemand.com/) with your SAP Cloud Platform user.
+To log onto the right SAP Cloud Platform Cloud Foundry endpoint, the right API endpoint URL is needed. Therefore, log into the [SAP Cloud Platform cockpit](https://cockpit.hanatrial.ondemand.com/) with your SAP Cloud Platform user.
 
 Click on **Enter Your Trial Account**.
 

--- a/tutorials/cp-portal-getting-started/cp-portal-getting-started.md
+++ b/tutorials/cp-portal-getting-started/cp-portal-getting-started.md
@@ -6,12 +6,12 @@ primary_tag: products>sap-cloud-platform-portal
 tags: [ tutorial>beginner, topic>cloud,products>sap-cloud-platform-portal ]
 ---
 
-## Prerequisites  
+## Prerequisites
  - **Proficiency:** Beginner
  - You have created a SAP Cloud Platform trial account. See [Sign up for a free trial account on SAP Cloud Platform](https://developers.sap.com/tutorials/hcp-create-trial-account.html).
 
 ## Details
-### You will learn  
+### You will learn
   - How to open SAP Cloud Platform cockpit
   - How to open your trial subaccount
   - How to enable the SAP Cloud Platform Portal service
@@ -21,7 +21,7 @@ tags: [ tutorial>beginner, topic>cloud,products>sap-cloud-platform-portal ]
 
 [ACCORDION-BEGIN [Step 1: ](Open SAP Cloud Platform cockpit)]
 
-1. Go to [SAP Cloud Platform](https://account.hanatrial.ondemand.com/).
+1. Go to [SAP Cloud Platform](https://cockpit.hanatrial.ondemand.com/).
 
     ![Log on screen](1-log-on-HCP.png)
 

--- a/tutorials/cp-starter-ibpm-employeeonboarding-1-setup/cp-starter-ibpm-employeeonboarding-1-setup.md
+++ b/tutorials/cp-starter-ibpm-employeeonboarding-1-setup/cp-starter-ibpm-employeeonboarding-1-setup.md
@@ -17,7 +17,7 @@ primary_tag: products>sap-cloud-platform
 
 To create service instances for business process management services, you need to ensure that you have the right set of entitlements in your trial account.
 
-1. In your web browser, open the [SAP Cloud Platform Trial cockpit](https://account.hanatrial.ondemand.com/cockpit).
+1. In your web browser, open the [SAP Cloud Platform Trial cockpit](https://cockpit.hanatrial.ondemand.com/cockpit).
 
 2. Navigate into the trial subaccount
 
@@ -50,7 +50,7 @@ Download the `BPMServicesFLP.zip` from  [GitHub](https://github.com/SAP-samples/
 
 [ACCORDION-BEGIN [Step 3: ](Access SAP Web IDE)]
 
-1. In your web browser, open the [SAP Cloud Platform Trial cockpit](https://account.hanatrial.ondemand.com/cockpit).
+1. In your web browser, open the [SAP Cloud Platform Trial cockpit](https://cockpit.hanatrial.ondemand.com/cockpit).
 
 2. Choose **Launch SAP Web IDE**.
 
@@ -74,7 +74,7 @@ Download the `BPMServicesFLP.zip` from  [GitHub](https://github.com/SAP-samples/
     |  :------------- | :-------------
     |  **API End Point**  | `https://api.cf.eu10.hana.ondemand.com` or `https://api.cf.us10.hana.ondemand.com` depending upon the region of your trial account
     |  **Organization**   | Your trial organization
-    |  **Space**          | Your trial space  
+    |  **Space**          | Your trial space
 
     > In the credentials popup, enter your trial user email and password. If you normally login via single-sign on, login with your domain password.
 
@@ -131,7 +131,7 @@ When you build and deploy this application, there will be new service instances 
 
 [ACCORDION-BEGIN [Step 6: ](Assign roles)]
 
-1. In your web browser, open the cockpit of [SAP Cloud Platform Trial](https://account.hanatrial.ondemand.com/cockpit).
+1. In your web browser, open the cockpit of [SAP Cloud Platform Trial](https://cockpit.hanatrial.ondemand.com/cockpit).
 
 2. Click **Enter Your Trial Account**
 

--- a/tutorials/cp-starter-ibpm-employeeonboarding-3-workflow/cp-starter-ibpm-employeeonboarding-3-workflow.md
+++ b/tutorials/cp-starter-ibpm-employeeonboarding-3-workflow/cp-starter-ibpm-employeeonboarding-3-workflow.md
@@ -16,7 +16,7 @@ primary_tag: products>sap-cloud-platform
 
 [ACCORDION-BEGIN [Step 1: ](Import Employee Onboarding sample application)]
 
-1. In your web browser, open [SAP Cloud Platform Trial cockpit](https://account.hanatrial.ondemand.com/cockpit).
+1. In your web browser, open [SAP Cloud Platform Trial cockpit](https://cockpit.hanatrial.ondemand.com/cockpit).
 
 2. Choose **Launch SAP Web IDE**.
 

--- a/tutorials/cp-ui5-ms-graph-create-app/cp-ui5-ms-graph-create-app.md
+++ b/tutorials/cp-ui5-ms-graph-create-app/cp-ui5-ms-graph-create-app.md
@@ -8,7 +8,7 @@ time: 20
 ---
 
 ## Details
-### You will learn  
+### You will learn
   - How to use the SAP Cloud Platform Web IDE to create an application in the Neo environment
   - How to consume a SAP Cloud Platform Connectivity destination
 
@@ -16,7 +16,7 @@ time: 20
 
 [ACCORDION-BEGIN [Step ](Create a HTML5 project)]
 
-1. Open your SAP Cloud Platform Cockpit (https://account.hanatrial.ondemand.com/cockpit) and open the **SAP Web IDE**.
+1. Open your SAP Cloud Platform Cockpit (https://cockpit.hanatrial.ondemand.com/cockpit) and open the **SAP Web IDE**.
 
     ![Launch SAP Web IDE](./launch_webide.png)
 

--- a/tutorials/cp-ui5-ms-graph-create-destination/cp-ui5-ms-graph-create-destination.md
+++ b/tutorials/cp-ui5-ms-graph-create-destination/cp-ui5-ms-graph-create-destination.md
@@ -7,11 +7,11 @@ tags: [  tutorial>beginner, topic>odata, products>sap-cloud-platform-connectivit
 time: 5
 ---
 
-## Prerequisites  
+## Prerequisites
  - [Know the concepts of OData](https://developers.sap.com/tutorials/odata-01-intro-origins.html)
 
 ## Details
-### You will learn  
+### You will learn
   - How to create destinations in the SAP Cloud Platform Neo environment
 
 ---
@@ -36,7 +36,7 @@ Create a new destination for the ES5 System if you don't have one.
 
 1. Download <a href="https://raw.githubusercontent.com/SAPDocuments/Tutorials/master/tutorials/cp-ui5-ms-graph-create-destination/ES5_Destination.txt" download>this descriptor file</a> (alternatively you can create the destination manually by clicking **New Destination**).
 
-2. Open your SAP Cloud Platform Cockpit (<https://account.hanatrial.ondemand.com/cockpit>), **scroll down** to the bottom of the page and click on **`Access Neo Trial`** in the SAP Cloud Platform cockpit.
+2. Open your SAP Cloud Platform Cockpit (<https://cockpit.hanatrial.ondemand.com/cockpit>), **scroll down** to the bottom of the page and click on **`Access Neo Trial`** in the SAP Cloud Platform cockpit.
 
     ![go to neo trial](./neo_cockpit.jpg)
 

--- a/tutorials/cp-workflow-1-getting-started-cf/cp-workflow-1-getting-started-cf.md
+++ b/tutorials/cp-workflow-1-getting-started-cf/cp-workflow-1-getting-started-cf.md
@@ -7,11 +7,11 @@ tags: [  tutorial>beginner, topic>cloud, products>sap-cloud-platform ]
 time: 5
 ---
 
-## Prerequisites  
+## Prerequisites
  - [Get a Trial Account](https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/42e7e54590424e65969fced1acd47694.html)
 
 ## Details
-### You will learn  
+### You will learn
   - How to enable the workflow service and create an instance in your SAP Cloud Platform account
   - How to assign the roles you need to develop and use workflow applications
 
@@ -110,7 +110,7 @@ time: 5
 
 [ACCORDION-BEGIN [Step 5: ](Enable the workflow extension and Cloud Foundry)]
 
-1. In your web browser, open the cockpit of [SAP Cloud Platform Trial](https://account.hanatrial.ondemand.com/cockpit).
+1. In your web browser, open the cockpit of [SAP Cloud Platform Trial](https://cockpit.hanatrial.ondemand.com/cockpit).
 
 2. Choose **Launch SAP Web IDE**.
 

--- a/tutorials/cp-workflow-2-create-module-cf/cp-workflow-2-create-module-cf.md
+++ b/tutorials/cp-workflow-2-create-module-cf/cp-workflow-2-create-module-cf.md
@@ -8,14 +8,14 @@ time: 15
 ---
 
 ## Details
-### You will learn  
+### You will learn
   - How to create ``multitarget`` application projects for your workflow in the SAP Web IDE.
   - How to deploy these projects to the SAP Cloud Platform.
 
 ---
 
 [ACCORDION-BEGIN [Step 1: ](Create an SAP Fiori launchpad project)]
-1. In your web browser, open the cockpit of [SAP Cloud Platform Trial](https://account.hanatrial.ondemand.com/cockpit).
+1. In your web browser, open the cockpit of [SAP Cloud Platform Trial](https://cockpit.hanatrial.ondemand.com/cockpit).
 
 2. Choose **Launch SAP Web IDE**.
 
@@ -80,13 +80,13 @@ time: 15
 
 
 [ACCORDION-BEGIN [Step 3: ](Configure the User Account and Authentication module to access SAP Fiori launchpad)]
-1. Right-click your `MyFLPProject` project, and choose **New** | **Folder**.  
+1. Right-click your `MyFLPProject` project, and choose **New** | **Folder**.
 
     ![Create New Folder](create-new-folder.png)
 
 2. Enter the folder name `MyFLPProject_UAA`, and choose **OK**.
 
-3. Right-click your `MyFLPProject_UAA` folder, and choose **New** | **File**.  
+3. Right-click your `MyFLPProject_UAA` folder, and choose **New** | **File**.
 
     ![Create New File](create-new-file.png)
 

--- a/tutorials/cp-workflow-2a-create-module-cf/cp-workflow-2a-create-module-cf.md
+++ b/tutorials/cp-workflow-2a-create-module-cf/cp-workflow-2a-create-module-cf.md
@@ -8,13 +8,13 @@ time: 5
 ---
 
 ## Details
-### You will learn  
+### You will learn
   - How to create ``multitarget`` application projects for your workflow in the SAP Web IDE.
   - How to deploy these projects to the SAP Cloud Platform.
 
 ---
 [ACCORDION-BEGIN [Step 1: ](Create a workflow project)]
-1. In your web browser, open the cockpit of [SAP Cloud Platform Trial](https://account.hanatrial.ondemand.com/cockpit).
+1. In your web browser, open the cockpit of [SAP Cloud Platform Trial](https://cockpit.hanatrial.ondemand.com/cockpit).
 
 2. Choose **Launch SAP Web IDE**.
 
@@ -34,7 +34,7 @@ time: 5
 
     ![Enter Name](enter-name.png)
 
-7. Do **not** select **Use HTML5 Application Repository**, and choose **Finish**.  
+7. Do **not** select **Use HTML5 Application Repository**, and choose **Finish**.
 
     ![Enter Workflow Name](enter-wf-name.png)
 

--- a/tutorials/cp-workflow-3-add-usertask-cf/cp-workflow-3-add-usertask-cf.md
+++ b/tutorials/cp-workflow-3-add-usertask-cf/cp-workflow-3-add-usertask-cf.md
@@ -8,16 +8,16 @@ time: 15
 ---
 
 ## Details
-### You will learn  
+### You will learn
   - How to start an instance of the workflow definition that you have defined using a start form
 
 ---
 [ACCORDION-BEGIN [Step 1: ](Launch SAP Web IDE)]
-1. In your web browser, open the cockpit of [SAP Cloud Platform Trial](https://account.hanatrial.ondemand.com/cockpit).
+1. In your web browser, open the cockpit of [SAP Cloud Platform Trial](https://cockpit.hanatrial.ondemand.com/cockpit).
 
 2. Choose **Launch SAP Web IDE**.
 
-   ![Launch SAP Web IDE](launchsapwebide.png)  
+   ![Launch SAP Web IDE](launchsapwebide.png)
 
 [DONE]
 [ACCORDION-END]
@@ -47,7 +47,7 @@ time: 15
     | Field                  | Value                  |
     | :--------------------- | :--------------------- |
     | **Name**               | **`ApprovalForm`**     |
-    | **Revision**           | **`1.0`**              |      
+    | **Revision**           | **`1.0`**              |
 
     ![Create Approval Form](create-approval-form.png)
 
@@ -63,10 +63,10 @@ A message confirms that the form has been created.
 
 2. To add two new fields, click **Add Field** twice, and enter the following data to define the fields:
 
-    | Label/Title      | Type          | Context Path                
+    | Label/Title      | Type          | Context Path
     | :--------------- | :------------ | :--------------------------
-    | **Title**        | **String**    | **`${context.product}`**    
-    | **Price**        | **Float**     | **`${context.price}`**      
+    | **Title**        | **String**    | **`${context.product}`**
+    | **Price**        | **Float**     | **`${context.price}`**
 
     ![Add Fields](add-fields.png)
 

--- a/tutorials/cp-workflow-4-approval-ui-cf/cp-workflow-4-approval-ui-cf.md
+++ b/tutorials/cp-workflow-4-approval-ui-cf/cp-workflow-4-approval-ui-cf.md
@@ -7,21 +7,21 @@ tags: [  tutorial>beginner, topic>cloud, products>sap-cloud-platform ]
 time: 15
 ---
 
-## Prerequisites  
+## Prerequisites
 - **Tutorials:** You have executed the previous tutorials in [Get started with SAP Cloud Platform workflows](https://developers.sap.com/group.cp-workflow-service.html).
 
 ## Details
-### You will learn  
+### You will learn
   - How to start an instance of the workflow definition that you have defined using a start form
 
 
 ---
 [ACCORDION-BEGIN [Step 1: ](Launch SAP Web IDE)]
-1. In your web browser, open the cockpit of [SAP Cloud Platform Trial](https://account.hanatrial.ondemand.com/cockpit).
+1. In your web browser, open the cockpit of [SAP Cloud Platform Trial](https://cockpit.hanatrial.ondemand.com/cockpit).
 
 2. Choose **Launch SAP Web IDE**.
 
-   ![Launch SAP Web IDE](launchsapwebide.png)  
+   ![Launch SAP Web IDE](launchsapwebide.png)
 
 [DONE]
 [ACCORDION-END]
@@ -70,7 +70,7 @@ time: 15
 2. Enter `Request Book` in the **Start Action Text** field, then choose **Select** next to **Workflow File Name**.
     The available workflow files are displayed.
 
-    ![Add Start Action and File](action-tab.png)  
+    ![Add Start Action and File](action-tab.png)
 
 4. Choose **/workflows/ApprovalWorkflow.workflow**, and choose **OK**.
 

--- a/tutorials/cp-workflow-add-usertask/cp-workflow-add-usertask.md
+++ b/tutorials/cp-workflow-add-usertask/cp-workflow-add-usertask.md
@@ -8,12 +8,12 @@ time: 15
 ---
 
 ## Details
-### You will learn  
+### You will learn
   - How to start an instance of the workflow definition that you have defined
 
 ---
 [ACCORDION-BEGIN [Step 1: ](Add the workflow apps to your homepage)]
-1. In your Web browser, open the cockpit of [SAP Cloud Platform](https://account.hanatrial.ondemand.com/cockpit).
+1. In your Web browser, open the cockpit of [SAP Cloud Platform](https://cockpit.hanatrial.ondemand.com/cockpit).
 2. Choose **Neo Trial**.
 3. Select **Services** from the left-hand navigation.
 4. Search for the **Workflow** service. Then select it, and choose **Fiori Launchpad (Default Site)**.
@@ -58,7 +58,7 @@ You now see the apps on your SAP Fiori launchpad homepage.
 
 [ACCORDION-BEGIN [Step 3: ](Access the workflow editor)]
 1. Open SAP Web IDE Full-Stack:
-  <ol type="a"><li>In your Web browser, open the cockpit of [SAP Cloud Platform](https://account.hanatrial.ondemand.com/cockpit).
+  <ol type="a"><li>In your Web browser, open the cockpit of [SAP Cloud Platform](https://cockpit.hanatrial.ondemand.com/cockpit).
   </li><li>Choose **Neo Trial**.
   </li><li>Then select **Services** from the left-hand navigation.
   </li><li>Search for the **Workflow** service. Then select it, and choose **SAP Web IDE Full-Stack**.</li></ol>

--- a/tutorials/cp-workflow-build-approval-ui/cp-workflow-build-approval-ui.md
+++ b/tutorials/cp-workflow-build-approval-ui/cp-workflow-build-approval-ui.md
@@ -7,18 +7,18 @@ tags: [  tutorial>beginner, topic>cloud, products>sap-cloud-platform ]
 time: 15
 ---
 
-## Prerequisites  
+## Prerequisites
 - **Tutorials:** You have executed the previous tutorials in [Get started with SAP Cloud Platform workflows](https://developers.sap.com/group.cp-workflow-service.html).
 
 ## Details
-### You will learn  
+### You will learn
   - How to define a basic form-based user task UI without having to cope with SAPUI5 coding
   - How to use it in a user task of a workflow
 
 
 ---
 [ACCORDION-BEGIN [Step 1: ](Open SAP Web IDE Full-Stack)]
-1. In your Web browser, open the cockpit of [SAP Cloud Platform](https://account.hanatrial.ondemand.com/cockpit).
+1. In your Web browser, open the cockpit of [SAP Cloud Platform](https://cockpit.hanatrial.ondemand.com/cockpit).
 2. Choose **Neo Trial**.
 3. Select **Services** from the left-hand navigation.
 4. Search for the **Workflow** service. Then select it, and choose **SAP Web IDE Full-Stack**.
@@ -68,7 +68,7 @@ time: 15
 
       - In column **Label/Title**, enter **`Title`**.
       - In column **Type**, select **String**.
-      - In column **Context Path**, enter **`${context.product}`**.      
+      - In column **Context Path**, enter **`${context.product}`**.
 
     &nbsp;
     Second row:

--- a/tutorials/cp-workflow-create-project/cp-workflow-create-project.md
+++ b/tutorials/cp-workflow-create-project/cp-workflow-create-project.md
@@ -8,14 +8,14 @@ time: 5
 ---
 
 ## Details
-### You will learn  
+### You will learn
   - How to create a project for your workflow in the SAP Web IDE Full-Stack.
   - How to deploy this project to the SAP Cloud Platform.
 
 ---
 
 [ACCORDION-BEGIN [Step 1: ](Access the SAP Web IDE Full-Stack)]
-1. In your Web browser, open the cockpit of [SAP Cloud Platform](https://account.hanatrial.ondemand.com/cockpit).
+1. In your Web browser, open the cockpit of [SAP Cloud Platform](https://cockpit.hanatrial.ondemand.com/cockpit).
 2. Choose **Neo Trial**.
 3. Select **Services** from the left-hand navigation.
 
@@ -57,7 +57,7 @@ time: 5
 
     ![Enter Workflow Name](enter-wf-name.png)
 
-8. Choose **Finish**.   
+8. Choose **Finish**.  
    You should now see a project with a workflow file in your workspace:
 
     ![Workflow Project](workflow-project.png)

--- a/tutorials/cp-workflow-getting-started/cp-workflow-getting-started.md
+++ b/tutorials/cp-workflow-getting-started/cp-workflow-getting-started.md
@@ -7,11 +7,11 @@ tags: [  tutorial>beginner, topic>cloud, products>sap-cloud-platform ]
 time: 5
 ---
 
-## Prerequisites  
+## Prerequisites
  - **Tutorials:** [Sign up for a free trial account on SAP Cloud Platform](hcp-create-trial-account)
 
 ## Details
-### You will learn  
+### You will learn
   - How to enable the workflow service in your SAP Cloud Platform account
   - How to assign the roles you need to develop and use workflow applications
 
@@ -19,7 +19,7 @@ time: 5
 
 [ACCORDION-BEGIN [Step 1: ](Open the SAP Cloud Platform cockpit)]
 
-1. In your Web browser, open the [SAP Cloud Platform](https://account.hanatrial.ondemand.com/cockpit) cockpit. If you do not have a trial account, see Prerequisites.
+1. In your Web browser, open the [SAP Cloud Platform](https://cockpit.hanatrial.ondemand.com/cockpit) cockpit. If you do not have a trial account, see Prerequisites.
 
 2. Choose **Neo Trial**.
 

--- a/tutorials/fiori-ios-scpms-custom-app-translation/fiori-ios-scpms-custom-app-translation.md
+++ b/tutorials/fiori-ios-scpms-custom-app-translation/fiori-ios-scpms-custom-app-translation.md
@@ -8,7 +8,7 @@ author_name: Kevin Muessig
 author_profile: https://github.com/KevinMuessig
 ---
 
-## Prerequisites  
+## Prerequisites
  - **Proficiency:** Intermediate
  - This tutorial is part of the [Customize UI's, themes and onboarding for iOS apps ](https://developers.sap.com/group.ios-sdk-custom.html) group
  &nbsp;
@@ -18,7 +18,7 @@ author_profile: https://github.com/KevinMuessig
 ## Details
 In this tutorial, you will use the SAP Cloud Platform's integration with SAP Translation Hub to add multilingual features to your iOS app generated with the SDK for iOS Assistant. This way, you can run your app in many languages, depending on your device's preferred language.
 
-### You will learn  
+### You will learn
 
  - How to enable SAP Translation Hub in your SAP Cloud Platform trial account
  - How to add your SAP Translation Hub account into the SDK for iOS Assistant
@@ -32,7 +32,7 @@ In this tutorial, you will use the SAP Cloud Platform's integration with SAP Tra
 
 [ACCORDION-BEGIN [Step 1: ](Enable SAP Translation Hub)]
 
-Log on to your SAP Cloud Platform account at [https://account.hanatrial.ondemand.com/cockpit/](https://account.hanatrial.ondemand.com/), log in and choose Neo Trial as landscape.
+Log on to your SAP Cloud Platform account at [https://cockpit.hanatrial.ondemand.com/cockpit/](https://cockpit.hanatrial.ondemand.com/), log in and choose Neo Trial as landscape.
 
 In the navigation on the left select **Services**.
 

--- a/tutorials/hana-mdc-usage-shine-du/hana-mdc-usage-shine-du.md
+++ b/tutorials/hana-mdc-usage-shine-du/hana-mdc-usage-shine-du.md
@@ -29,7 +29,7 @@ time: 30
 
     ![Account Information Page](1.png)
 
-    If you are confused about the account name and user name, you can go to [SAP Cloud Platform Cockpit](https://account.hanatrial.ondemand.com/) and there you can see your account name on the tile and if you click on it, then in the URL. The user name is the same name, just without the "trial" part.
+    If you are confused about the account name and user name, you can go to [SAP Cloud Platform Cockpit](https://cockpit.hanatrial.ondemand.com/) and there you can see your account name on the tile and if you click on it, then in the URL. The user name is the same name, just without the "trial" part.
 
 5. Choose your tenant database, which you've already created and enter the database user name **SYSTEM** and password you specified when you created this database. Then choose **Finish**.
 
@@ -47,7 +47,7 @@ time: 30
     ![Download ZIP](4.png)
 
 2. Create another database user.
-    Go to your [SAP Cloud Platform Cockpit](https://account.hanatrial.ondemand.com/), then **Persistence > Databases & Schemas** and open your tenant database. Then click on **SAP HANA Cockpit** and enter your **SYSTEM** database user name and password.
+    Go to your [SAP Cloud Platform Cockpit](https://cockpit.hanatrial.ondemand.com/), then **Persistence > Databases & Schemas** and open your tenant database. Then click on **SAP HANA Cockpit** and enter your **SYSTEM** database user name and password.
 3. From the **SAP HANA Database Administration** page, choose **Manage Roles and Users**.
 
     ![Administration Page](5.png)
@@ -130,7 +130,7 @@ You can also import Delivery Unit using the Eclipse IDE
 
 ### Edit the Code and Run the Application
 
-1. Go to your [SAP Cloud Platform Cockpit](https://account.hanatrial.ondemand.com/), then *Persistence > Database & Schemas* and open your tenant database. Then click on *SAP HANA Web-based Development Workbench.*
+1. Go to your [SAP Cloud Platform Cockpit](https://cockpit.hanatrial.ondemand.com/), then *Persistence > Database & Schemas* and open your tenant database. Then click on *SAP HANA Web-based Development Workbench.*
 2. Select *Editor* and enter your **`SHINE_DEV`** database user name and password.
 3. Select **`sap > hana > democontent > epm > index.html`**
 
@@ -145,7 +145,7 @@ You can also import Delivery Unit using the Eclipse IDE
 
 ### Export the Delivery Unit
 
-1. Go to your [SAP Cloud Platform Cockpit](https://account.hanatrial.ondemand.com/), then *Persistence > Database & Schemas* and open your tenant database. Then click on **SAP HANA Cockpit**.
+1. Go to your [SAP Cloud Platform Cockpit](https://cockpit.hanatrial.ondemand.com/), then *Persistence > Database & Schemas* and open your tenant database. Then click on **SAP HANA Cockpit**.
 2. Enter your **`SHINE_DEV`** database user name and password.
 3. Choose **`HANA Application Lifecycle Management > Delivery Units > HCO_DEMOCONTENT`**
 4. Select the **Export** button above.

--- a/tutorials/hana-web-development-workbench/hana-web-development-workbench.md
+++ b/tutorials/hana-web-development-workbench/hana-web-development-workbench.md
@@ -6,16 +6,16 @@ tags: [ products>sap-hana, products>sap-cloud-platform, tutorial>beginner]
 time: 15
 ---
 
-## Prerequisites  
+## Prerequisites
  - **Tutorials:** You need a HANA account or server. Pick one of the following:
-   - [Get a free account in SAP Cloud Platform](https://account.hanatrial.ondemand.com/register)
+   - [Get a free account in SAP Cloud Platform](https://cockpit.hanatrial.ondemand.com/cockpit)
    - [SAP HANA, express edition](https://developers.sap.com/topics/sap-hana-express.html)
 
 ## Next Steps
 [Access your first Data from a native SAP HANA Application](https://developers.sap.com/tutorials/hana-data-access-authorizations.html)
 
 ## Details
-### You will learn  
+### You will learn
 1. How to use the SAP HANA Web-based Development Workbench.
 2. How to develop a simple server-side application.
 3. How to publish and run an application.
@@ -33,7 +33,7 @@ time: 15
 
 Each Trial HANA MDC instance comes with the HANA Web-based Development Workbench. The workbench allows you to develop on HANA without the need to set up a local development environment.
 
-Login to the [HANA Cloud Cockpit](https://account.hanatrial.ondemand.com/cockpit) with your free developer edition account.
+Login to the [HANA Cloud Cockpit](https://cockpit.hanatrial.ondemand.com/cockpit) with your free developer edition account.
 Choose Persistence in the left column menu and then Database & Schemas. You will need to create your new instance. To do this simply give it a name, enable web access and of course give a password. This password you will need to remember as it is the password for your SYSTEM user and how you will be able to access the server.
 
 ![New Database and Schema](https://raw.githubusercontent.com/SAPDocuments/Tutorials/master/tutorials/hana-web-development-workbench/1.png)

--- a/tutorials/hcp-abh-getting-started/hcp-abh-getting-started.md
+++ b/tutorials/hcp-abh-getting-started/hcp-abh-getting-started.md
@@ -7,14 +7,14 @@ author_profile: https://github.com/mhassett92
 auto_validation: true
 tags: [  tutorial>beginner, products>sap-cloud-platform ]
 ---
-## Prerequisites  
+## Prerequisites
  - **Proficiency:** Beginner
 
 ## Next Steps
  - [Testing API Business Hub APIs with Curl](https://developers.sap.com/tutorials/hcp-abh-test-locally.html)
 
 ## Details
-### You will learn  
+### You will learn
 Want to learn more about the new SAP API Business Hub? Not sure where to get started? Find more about how to find and enable the SAP API Business Hub in your SAP Cloud Platform instance. Once you are in the SAP API Business Hub, start learning about and testing one of the many available APIs.
 
 ### Time to Complete
@@ -23,7 +23,7 @@ Want to learn more about the new SAP API Business Hub? Not sure where to get sta
 ---
 
 [ACCORDION-BEGIN [Step 1: ](Open SAP Cloud Platform Services)]
-Open your [SAP Cloud Platform Cockpit](https://account.hanatrial.ondemand.com/cockpit). If you do not have an account yet, sign up for a free trial account first.
+Open your [SAP Cloud Platform Cockpit](https://cockpit.hanatrial.ondemand.com/cockpit). If you do not have an account yet, sign up for a free trial account first.
 
 In your SAP Cloud Platform account, select **Services** from the side menu.
 

--- a/tutorials/hcp-apim-webide-int/hcp-apim-webide-int.md
+++ b/tutorials/hcp-apim-webide-int/hcp-apim-webide-int.md
@@ -6,11 +6,11 @@ primary_tag: products>sap-api-management
 tags: [  tutorial>beginner,  products>sap-cloud-platform, products>sap-web-ide, products>sap-api-management ]
 time: 20
 ---
-## Prerequisites  
+## Prerequisites
 - **Tutorials:** [Protect your API Proxy by adding an Application Key Verification](https://developers.sap.com/tutorials/hcp-apim-verify-api.html)
 
 ## Details
-### You will learn  
+### You will learn
 Since SAP Cloud Platform, API Management is one of many services on the SAP Cloud Platform it also offers a deep integration in SAP Web IDE. With this integration you can easily browse and consume services from SAP Cloud Platform, API Management and directly create SAP Fiori like SAPUI5 applications leveraging one of the templates offered in SAP Web IDE.
 
 ---
@@ -38,7 +38,7 @@ You will see how a special security token known as the "API Key" or "Application
 
 [ACCORDION-BEGIN [Step 4: ](Log onto the SAP Cloud Platform Cockpit)]
 
-Log onto your [SAP Cloud Platform Cockpit](https://account.hanatrial.ondemand.com/cockpit).
+Log onto your [SAP Cloud Platform Cockpit](https://cockpit.hanatrial.ondemand.com/cockpit).
 
 ![Log on to CP Cockpit](01-hcp.png)
 
@@ -297,7 +297,7 @@ In order to get the API Key you need to open the **API Developer Portal** in a n
 
 [ACCORDION-BEGIN [Step 20: ](Click Consume)]
 
-Click on the **Hamburger menu** and click on **Consume**   
+Click on the **Hamburger menu** and click on **Consume**
 
 ![Click on Consume](28-ClickOnConsume.png)
 

--- a/tutorials/hcp-create-trial-account/hcp-create-trial-account.md
+++ b/tutorials/hcp-create-trial-account/hcp-create-trial-account.md
@@ -10,7 +10,7 @@ time: 15
 ---
 
 ## Details
-### You will learn  
+### You will learn
   - How to register on the SAP website
   - How to start your SAP Cloud Platform trial
   - Learn how to 90 days trial works
@@ -61,7 +61,7 @@ After activating your account, you will see the following screen.
 
 [ACCORDION-BEGIN [Step : ](Log on to SAP Cloud Platform)]
 
-After activation, or if you already had an SAP account, go to the <a href="https://account.hanatrial.ondemand.com/" target="new"><b>SAP Cloud Platform Trial</b></a>  page and click **Log On**.
+After activation, or if you already had an SAP account, go to the <a href="https://cockpit.hanatrial.ondemand.com/" target="new"><b>SAP Cloud Platform Trial</b></a>  page and click **Log On**.
 
 You will see an dialog to confirm the terms and condition for the SAP Cloud Platform Developer Edition. Check the check boxes and click **Accept**. This simply adds the SAP.com registration to your login account on SAP Cloud Identity. There is no cost associated with this upgrade.
 
@@ -91,7 +91,7 @@ Click on **Log on** to log on to your verified account.
 
  ![Log on again](logon-again.png)
 
-Here, you can now create a subaccount which lives in a geographic region. Choose one of regions from this list.    
+Here, you can now create a subaccount which lives in a geographic region. Choose one of regions from this list.
 
 > We suggest the *Europe (Frankfurt)* region because it has the largest list of services.  If you want to use a region closer to you, [check to be certain it has the services you want before selecting it](https://help.sap.com/doc/aa1ccd10da6c4337aa737df2ead1855b/Cloud/en-US/3b642f68227b4b1398d2ce1a5351389a.html?3b642f68227b4b1398d2ce1a5351389a.html).
 
@@ -127,7 +127,7 @@ To get to the space, in which your applications and services live, click on the 
 
 A Cloud Foundry space is the logical container of your runtime artefacts such as **Applications**, and **Service Instances**.
 
-The **Applications** tab is where all of your applications will be listed, and new applications can be added in to your Cloud Foundry runtime environment.  
+The **Applications** tab is where all of your applications will be listed, and new applications can be added in to your Cloud Foundry runtime environment.
 
 ![The Applications Tab](space-apps.png)
 

--- a/tutorials/odata-05-data-model-service/odata-05-data-model-service.md
+++ b/tutorials/odata-05-data-model-service/odata-05-data-model-service.md
@@ -70,7 +70,7 @@ This means that the CDS facilities in SAP Web IDE will do the right things at th
 
 [ACCORDION-BEGIN [Step 4: ](Check your CF quota)]
 
-Before proceeding, it's worth checking that you have enough quota available for this tutorial. Go to the Cloud Foundry space for your trial account in your [SAP Cloud Platform cockpit](https://account.hanatrial.ondemand.com/cockpit#/home/trialhome) -- follow the Cloud Foundry Trial link, selecting your subaccount where you should then see the subaccount overview, which will look something like this:
+Before proceeding, it's worth checking that you have enough quota available for this tutorial. Go to the Cloud Foundry space for your trial account in your [SAP Cloud Platform cockpit](https://cockpit.hanatrial.ondemand.com/cockpit) -- follow the Cloud Foundry Trial link, selecting your subaccount where you should then see the subaccount overview, which will look something like this:
 
 ![Subaccount overview](subaccount-overview.png)
 

--- a/tutorials/productconfiguration-ui5-app-create/productconfiguration-ui5-app-create.md
+++ b/tutorials/productconfiguration-ui5-app-create/productconfiguration-ui5-app-create.md
@@ -28,7 +28,7 @@ Create a free trial account on the SAP Cloud Platform to be able to use the Web 
 Fill the registration form by providing you name, email and a password. Once your account is created, log in and launch SAP Web IDE.
 
 ![step-1-sap-web-IDE](step-1-sap-web-IDE.png)
-Direct link: (https://account.hanatrial.ondemand.com/cockpit)
+Direct link: (https://cockpit.hanatrial.ondemand.com/cockpit)
 
 [DONE]
 [ACCORDION-END]

--- a/tutorials/react-add-odata/react-add-odata.md
+++ b/tutorials/react-add-odata/react-add-odata.md
@@ -4,7 +4,7 @@ description: Add dynamically retrieved data with OData support
 primary_tag: topic>html5
 tags: [  tutorial>beginner, topic>html5, topic>mobile, topic>odata, products>sap-cloud-platform ]
 ---
-## Prerequisites  
+## Prerequisites
 - **Proficiency:** Beginner
 - **Northwind Destination** [Set up the Northwind service destination in the SAP Cloud Platform cockpit](https://developers.sap.com/tutorials/hcp-create-destination.html)
 - **Tutorial:** [Convert components from static to dynamic](https://developers.sap.com/tutorials/react-dynamic-components.html)
@@ -14,7 +14,7 @@ tags: [  tutorial>beginner, topic>html5, topic>mobile, topic>odata, products>sap
 
 
 ## Details
-### You will learn  
+### You will learn
 In this tutorial series, we will explore another technology for Single Page Application (SPA) development - React.  React is another popular web framework, and is used by many companies for both internal and client-facing systems.  These tutorials will parallel our SAPUI5 tutorials, building a visual interface using Angular, and connecting it to an OData back end service.
 
 ### Time to Complete
@@ -23,7 +23,7 @@ In this tutorial series, we will explore another technology for Single Page Appl
 ---
 
 #### REACT tutorial series
-**Step 6**: Convert the React components to pull data from a web based [OData reference](http://www.odata.org/odata-services/) service.  The data source is called `Northwind`, and appears under the `ODAta v3` tab.  
+**Step 6**: Convert the React components to pull data from a web based [OData reference](http://www.odata.org/odata-services/) service.  The data source is called `Northwind`, and appears under the `ODAta v3` tab.
 
 **NOTE** If you have not yet set up the Northwind destination in the SAP Cloud Platform cockpit, you must do that first.  Follow the steps below, in the *Warning* dialog box, to make sure this is set up correctly.
 
@@ -41,7 +41,7 @@ The steps for this tutorial are:
 >
 > If you have not configured the Northwind service in SAP Cloud Platform, you must do that first.  To verify that you have configured SAP Cloud Platform correctly, do the following:
 >
-> - Open a new browser page to the **[SAP Cloud Platform Cockpit](https://account.hanatrial.ondemand.com/cockpit)**
+> - Open a new browser page to the **[SAP Cloud Platform Cockpit](https://cockpit.hanatrial.ondemand.com/cockpit)**
 > - In the right hand navigation, select **Connectivity**, then select **Destinations**
 > - Look for the Destination called `Northwind`.
 >
@@ -102,7 +102,7 @@ In the `main.js` file, select all of the test data (starting with `var testData 
 
 >Don't forget to save your file.
 
-![delete the test data](2-1.png)   
+![delete the test data](2-1.png)
 
 
 [ACCORDION-END]
@@ -181,13 +181,13 @@ Run your application.  20 rows of data should be displayed, coming from the ODat
 
 #### Using SAP Cloud Platform Destinations
 
-The sample application uses the [SAP Cloud Platform (HCP) destinations](https://help.hana.ondemand.com/help/frameset.htm?e4f1d97cbb571014a247d10f9f9a685d.html) to access the sample data.  
+The sample application uses the [SAP Cloud Platform (HCP) destinations](https://help.hana.ondemand.com/help/frameset.htm?e4f1d97cbb571014a247d10f9f9a685d.html) to access the sample data.
 
 We do this using the `neo-app.json` file.  This is the [Application Descriptor File](https://help.hana.ondemand.com/help/frameset.htm?aed1ffa3f3e741b3a4573c9e475aa2a4.html), and can be used to configure your application running inside HCP.
 
 **Why doesn't the sample application just connect directly to the OData test service?**
 
-Normally, you can do this.  In fact, it's the recommended method.  But we are working around a bug.  
+Normally, you can do this.  In fact, it's the recommended method.  But we are working around a bug.
 
 There are two things happening here.  First, all the major web browsers prevent you from loading insecure data in to a secure page.  That is called [Mixed Content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content).  If the original web page is secure, the browser will demand all data is secure as well.  So, the browser automatically uses HTTPS connections for all data.
 

--- a/tutorials/react-getting-started/react-getting-started.md
+++ b/tutorials/react-getting-started/react-getting-started.md
@@ -4,7 +4,7 @@ description: Start to build a React JavaScript project using SAP Web IDE on SAP 
 primary_tag: products>sap-cloud-platform
 tags: [  tutorial>beginner, topic>html5, topic>mobile, topic>odata, products>sap-cloud-platform, products>sap-web-ide ]
 ---
-## Prerequisites  
+## Prerequisites
  - **Proficiency:** Beginner
  - **Trial Account** You will need a SAP Cloud Platform trial account for this tutorial series.  [Create an SAP Cloud Platform Trial Account](https://developers.sap.com/tutorials/hcp-create-trial-account.html)
 
@@ -13,7 +13,7 @@ tags: [  tutorial>beginner, topic>html5, topic>mobile, topic>odata, products>sap
 - **Tutorial** [Create the Bootstrap Template](https://developers.sap.com/tutorials/react-bootstrap-template.html)
 
 ## Details
-### You will learn  
+### You will learn
 In this tutorial series, we will explore another technology for Single Page Application (SPA) development - REACT.  REACT is another popular web framework, and is used by many companies for both internal and client-facing systems.  These tutorials will parallel our SAPUI5 tutorials, building a visual interface using Angular, and connecting it to an OData back end service.
 
 ### Time to Complete
@@ -34,7 +34,7 @@ This first tutorial will start by opening the IDE and getting the basic parts of
 
 [ACCORDION-BEGIN [Step 1: ](Open SAP Cloud Platform console)]
 
-Open the [SAP Cloud Platform console](https://account.hanatrial.ondemand.com/)
+Open the [SAP Cloud Platform console](https://cockpit.hanatrial.ondemand.com/)
 
 > **Can not create a developer account?**
 >
@@ -48,7 +48,7 @@ Open the [SAP Cloud Platform console](https://account.hanatrial.ondemand.com/)
 
 [ACCORDION-BEGIN [Step 2: ](Enable SAP Web IDE)]
 
-You should now be in the SAP Cloud Platform Cockpit, as shown below.  Click on the **Services** menu item on the left.  
+You should now be in the SAP Cloud Platform Cockpit, as shown below.  Click on the **Services** menu item on the left.
 
 Next, click on the **SAP Web IDE** box.  You may need to scroll down to find this box.
 

--- a/tutorials/sapui5-webide-open-webide/sapui5-webide-open-webide.md
+++ b/tutorials/sapui5-webide-open-webide/sapui5-webide-open-webide.md
@@ -8,11 +8,11 @@ primary_tag: products>sap-cloud-platform-for-the-cloud-foundry-environment
 tags: [  tutorial>beginner, topic>html5, topic>sapui5, products>sap-cloud-platform ]
 time: 5
 ---
-## Prerequisites  
+## Prerequisites
 - **Tutorial:** If you don't have an SAP Cloud Platform account, follow the tutorial to [set up a free developer account](hcp-create-trial-account).
 
 ## Details
-### You will learn  
+### You will learn
   - How to enable SAP Web IDE Full-Stack inside of SAP Cloud Platform
   - How to open SAP Web IDE Full-Stack
 
@@ -23,7 +23,7 @@ time: 5
 
 
 
-Open your SAP Cloud Platform account (if you have a free developer account, click [here](https://account.hanatrial.ondemand.com/) to open the home page).
+Open your SAP Cloud Platform account (if you have a free developer account, click [here](https://cockpit.hanatrial.ondemand.com/) to open the home page).
 
  Click on **Launch SAP Web IDE** to see navigate further.
 

--- a/tutorials/webide-multi-cloud/webide-multi-cloud.md
+++ b/tutorials/webide-multi-cloud/webide-multi-cloud.md
@@ -10,7 +10,7 @@ time: 5
 ---
 
 ## Details
-### You will learn  
+### You will learn
   - How to open SAP Web IDE Full-Stack
 
 You can use many different tools to build and deploy apps on the SAP Cloud Platform, but we recommend SAP Web IDE, a service of SAP Cloud Platform. In this tutorial, you'll locate it and access it, all from your browser, without needing to install anything.
@@ -22,7 +22,7 @@ You can use many different tools to build and deploy apps on the SAP Cloud Platf
 
 
 
-Open your SAP Cloud Platform account (if you have a free developer account, click [here](https://account.hanatrial.ondemand.com/) to open the home page).
+Open your SAP Cloud Platform account (if you have a free developer account, click [here](https://cockpit.hanatrial.ondemand.com/) to open the home page).
 
  Click on **Launch SAP Web IDE** to see navigate further.
 


### PR DESCRIPTION
Replaces account.hanatrial with cockpit.hanatrial
to avoid initial redirect to new trial application.
Exception: deep links to Neo content.