### PR TITLE
Remove HTML5 Application entitlement requirement

### DIFF
--- a/tutorials/iot-ds-4-build-test/iot-ds-4-build-test.md
+++ b/tutorials/iot-ds-4-build-test/iot-ds-4-build-test.md
@@ -39,7 +39,6 @@ If you make any changes to an MTA project, you'll need to build and deploy the p
     Entitlement | Unit
     ------------ | -------------
     Portal|1 (or unlimited)
-    HTML5 Application|2
     Application Runtime Memory| 1 Gib (Minimum)
     Destination|1
 


### PR DESCRIPTION
It is no longer required to have HTML5 Application entitlement to deploy applications to HTML5 application repository because it is now a utility service: https://help.sap.com/doc/43b304f99a8145809c78f292bfc0bc58/Cloud/en-US/98bf747111574187a7c76f8ced51cfeb.html?sel1=HTML5%20Applications&date=all&from=2020-08-01