### PR TITLE
cp-connectivity-create-secure-tunnel: Correction of step text

### DIFF
--- a/tutorials/cp-connectivity-create-secure-tunnel/cp-connectivity-create-secure-tunnel.md
+++ b/tutorials/cp-connectivity-create-secure-tunnel/cp-connectivity-create-secure-tunnel.md
@@ -25,7 +25,7 @@ Before you can access data from the Cloud Connector in an application on SAP Clo
 
 1. Go to [Your SAP Cloud Platform Trial](https://account.hanatrial.ondemand.com/cockpit) | **Cloud Foundry Trial**, and navigate to your subaccount.
 
-1. The card with your subaccount information will show the sub-account name **trial** by default. If the card shows the subdomain instead of your subaccount's ID choose the flip icon:
+1. The card with your subaccount information will show the sub-account name **trial** by default. Choose **More Info** to display your subaccount's ID:
 
     ![subaccount ID](step-01-Find-Trial-ID-001.png)
 


### PR DESCRIPTION
My bad - after PR #6253 was merged I noticed that the text of step 1 had to be changed to match the new screenshot.

This PR fixes it. I checked the steps where are changed the other screenshots. Those are fine. 